### PR TITLE
feat(simulator): add patient goroutine with template vital signs

### DIFF
--- a/simulator/cmd/internal/patient.go
+++ b/simulator/cmd/internal/patient.go
@@ -1,0 +1,48 @@
+package internal
+
+import (
+	"encoding/json"
+	"os"
+	"time"
+)
+
+type Patient struct {
+	ID string
+}
+
+func NewPatient(id string) *Patient {
+	return &Patient{
+		ID: id,
+	}
+}
+
+func (p *Patient) Run() {
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	enc := json.NewEncoder(os.Stdout)
+	end := time.After(1 * time.Minute)
+	for {
+		select {
+		case <-ticker.C:
+			enc.Encode(p.templateVitals())
+		case <-end:
+			return
+		}
+	}
+}
+
+func (p *Patient) templateVitals() VitalSigns {
+	return VitalSigns{
+		PatientID:          p.ID,
+		Timestamp:          time.Now().UTC(),
+		RespirationRate:    15,
+		OxygenSaturation:   98,
+		SupplementalO2:     false,
+		Temperature:        37.0,
+		SystolicBP:         120,
+		HeartRate:          72,
+		ConsciousnessLevel: Alert,
+		SimulatorState:     Stable,
+	}
+}

--- a/simulator/cmd/internal/vitals.go
+++ b/simulator/cmd/internal/vitals.go
@@ -1,0 +1,35 @@
+package internal
+
+import "time"
+
+type SimulatorState string
+
+const (
+	Stable        SimulatorState = "STABLE"
+	Deteriorating SimulatorState = "DETERIORATING"
+	Critical      SimulatorState = "CRITICAL"
+)
+
+type ConsciousnessLevel string
+
+const (
+	Alert        ConsciousnessLevel = "ALERT"
+	Voice        ConsciousnessLevel = "VOICE"
+	Pain         ConsciousnessLevel = "PAIN"
+	Unresponsive ConsciousnessLevel = "UNRESPONSIVE"
+)
+
+type VitalSigns struct {
+	PatientID      string         `json:"patient_id"`
+	Timestamp      time.Time      `json:"timestamp"`
+	SimulatorState SimulatorState `json:"simulator_state"`
+
+	// 7 NEWS2 parameters
+	RespirationRate    int                `json:"respiration_rate"`
+	OxygenSaturation   int                `json:"oxygen_saturation"`
+	SupplementalO2     bool               `json:"supplemental_o2"`
+	Temperature        float64            `json:"temperature"`
+	SystolicBP         int                `json:"systolic_bp"`
+	HeartRate          int                `json:"heart_rate"`
+	ConsciousnessLevel ConsciousnessLevel `json:"consciousness_level"`
+}

--- a/simulator/cmd/simulator/main.go
+++ b/simulator/cmd/simulator/main.go
@@ -2,14 +2,28 @@ package main
 
 import (
 	"fmt"
-	"os"
-	"os/signal"
-	"syscall"
+	"time"
 )
 
+func printOK(done chan struct{}) {
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	end := time.After(1 * time.Minute)
+
+	for {
+		select {
+		case <-ticker.C:
+			fmt.Println("ok!")
+		case <-end:
+			done <- struct{}{}
+			return
+		}
+	}
+}
+
 func main() {
-	fmt.Println("simulator started")
-	quit := make(chan os.Signal, 1)
-	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
-	<-quit
+	done := make(chan struct{})
+	go printOK(done)
+	<-done
 }

--- a/simulator/cmd/simulator/main.go
+++ b/simulator/cmd/simulator/main.go
@@ -1,29 +1,15 @@
 package main
 
 import (
-	"fmt"
-	"time"
+	"github.com/agusrichard/icu-vitals-stream/simulator/cmd/internal"
 )
 
-func printOK(done chan struct{}) {
-	ticker := time.NewTicker(1 * time.Second)
-	defer ticker.Stop()
-
-	end := time.After(1 * time.Minute)
-
-	for {
-		select {
-		case <-ticker.C:
-			fmt.Println("ok!")
-		case <-end:
-			done <- struct{}{}
-			return
-		}
-	}
-}
-
 func main() {
+	patient := internal.NewPatient("richard")
 	done := make(chan struct{})
-	go printOK(done)
+	go func() {
+		defer close(done)
+		patient.Run()
+	}()
 	<-done
 }


### PR DESCRIPTION
## Summary

- Introduced `VitalSigns` struct covering all 7 NEWS2 parameters plus metadata (`patient_id`, `timestamp`, `simulator_state`), along with `SimulatorState` and `ConsciousnessLevel` string enums
- Added `Patient` type with a `Run()` method that ticks every second for one minute, encoding template (fixed healthy-baseline) vitals as JSON to stdout
- Updated `main.go` to launch a patient goroutine via a channel-based done pattern, replacing the placeholder signal-wait skeleton

## Test plan

- [x] Run `go run ./cmd/simulator` and verify JSON lines appear on stdout every second
- [x] Confirm each line contains all 7 NEWS2 fields plus `patient_id` and `timestamp`
- [x] Verify process exits cleanly after one minute

🤖 Generated with [Claude Code](https://claude.ai/claude-code)