### PR TITLE
feat(simulator): add patient state machine with Markov chain transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ In real ICUs, vital signs are charted every 1–4 hours, and clinical deteriorat
 
 ### Data Flow
 
-1. **Go simulator** generates vital signs for N virtual patients, each modeled as an independent goroutine with an underlying clinical state machine (stable, deteriorating-sepsis, deteriorating-respiratory, post-op recovering, etc.).
+1. **Go simulator** generates vital signs for N virtual patients, each modeled as an independent goroutine with an underlying clinical state machine (see [Clinical States](#clinical-states)).
 2. **Kafka** serves as the durable event backbone, with topics keyed by `patient_id` to preserve per-patient ordering.
 3. **Rust consumer** maintains per-patient rolling windows in memory, computes NEWS2 in real time, deduplicates and emits alerts on score transitions, and snapshots state to TimescaleDB for the live dashboard.
 4. **PySpark** runs both Structured Streaming jobs (5-minute and 1-hour aggregates) and nightly batch jobs (ward KPIs, ML training for deterioration prediction).
@@ -69,23 +69,203 @@ Schemas are managed via a Schema Registry (Avro).
 
 ## The NEWS2 Scoring Algorithm
 
-The Rust consumer implements the NEWS2 score, which assigns 0–3 points to each of seven physiological parameters:
+NEWS2 (National Early Warning Score 2) was published by the Royal College of Physicians in December 2017 and has received formal NHS England endorsement as the standard early warning system for identifying acutely ill patients, including those with sepsis. **No scoring threshold changes have been issued since the 2017 publication** — a 2022 update revised only the observation chart formatting.
 
-| Parameter | Measured |
+The Rust consumer implements NEWS2 by scoring each of seven physiological parameters from 0–3 based on how far the measurement deviates from normal, then summing them. The maximum possible total is 20.
+
+### Respiratory Rate (breaths/min)
+
+| Range | Score |
 |---|---|
-| Respiratory rate | breaths/min |
-| SpO₂ | oxygen saturation % |
-| Supplemental oxygen | yes / no |
-| Temperature | °C |
-| Systolic blood pressure | mmHg |
-| Heart rate | bpm |
-| Consciousness (ACVPU) | Alert / Confusion / Voice / Pain / Unresponsive |
+| ≤ 8 | 3 |
+| 9–11 | 1 |
+| 12–20 | 0 |
+| 21–24 | 2 |
+| ≥ 25 | 3 |
 
-Aggregate scores trigger escalation tiers:
+### SpO₂
 
-- **0–4**: routine monitoring
-- **5–6** (or any single parameter scoring 3): urgent clinical review
-- **≥ 7**: emergency response
+Scale 1 applies to all patients in this simulator. Scale 2 (for COPD / hypercapnic respiratory failure patients who target a lower SpO₂ of 88–92%) is out of scope — none of the six clinical states model chronic CO₂ retention.
+
+| Range | Score |
+|---|---|
+| ≤ 91% | 3 |
+| 92–93% | 2 |
+| 94–95% | 1 |
+| ≥ 96% | 0 |
+
+### Supplemental Oxygen
+
+| | Score |
+|---|---|
+| Room air | 0 |
+| Any supplemental O₂ | 2 |
+
+### Systolic Blood Pressure (mmHg)
+
+| Range | Score |
+|---|---|
+| ≤ 90 | 3 |
+| 91–100 | 2 |
+| 101–110 | 1 |
+| 111–219 | 0 |
+| ≥ 220 | 3 |
+
+### Heart Rate (bpm)
+
+| Range | Score |
+|---|---|
+| ≤ 40 | 3 |
+| 41–50 | 1 |
+| 51–90 | 0 |
+| 91–110 | 1 |
+| 111–130 | 2 |
+| ≥ 131 | 3 |
+
+### Temperature (°C)
+
+| Range | Score |
+|---|---|
+| ≤ 35.0 | 3 |
+| 35.1–36.0 | 1 |
+| 36.1–38.0 | 0 |
+| 38.1–39.0 | 1 |
+| ≥ 39.1 | 2 |
+
+### Consciousness (ACVPU)
+
+New Confusion was added in NEWS2 (vs the original NEWS) as an early sepsis and hypoxia marker.
+
+| Level | Score |
+|---|---|
+| Alert | 0 |
+| New Confusion | 3 |
+| Voice | 3 |
+| Pain | 3 |
+| Unresponsive | 3 |
+
+### Escalation Thresholds
+
+| Score | Risk | Required Response |
+|---|---|---|
+| 0 | Low | Routine monitoring, minimum 12-hourly obs |
+| 1–4 | Low | Minimum 12-hourly; nurse decides whether to escalate |
+| Any single parameter = 3 | Low–Medium | Urgent assessment by a competent registered nurse |
+| 5–6 | Medium | Urgent clinician review; minimum hourly obs |
+| ≥ 7 | **High** | Emergency response team; consider HDU/ICU transfer; continuous monitoring |
+
+Sepsis-specific rule: a score ≥ 5 in a patient with known or suspected infection should trigger the sepsis bundle (lactate, blood cultures, antibiotics).
+
+### How the Score and Clinical State Are Used Across the Pipeline
+
+The Rust scorer does two things with each reading:
+
+1. **Computes the NEWS2 aggregate score** and per-parameter subscores, firing an alert when thresholds are crossed.
+2. **Classifies the current clinical state** using rule-based pattern matching on the current snapshot — e.g. high temp + low BP + high HR → sepsis; very low SpO₂ + very high RR + supplemental O₂ → respiratory failure. This is deterministic, explainable, and fast: exactly what a real-time clinical alerter needs to be.
+
+The PySpark ML model does something the Rust scorer fundamentally cannot: it sees a **time series** of parameter values across a rolling window and detects deteriorating trends *before thresholds are crossed*. A patient whose heart rate has drifted 75 → 85 → 95 → 108 over 10 minutes may still have a NEWS2 score of 2, but the trajectory already matches a pre-sepsis pattern the model has learned.
+
+The key distinction is **snapshot vs trajectory**. The Rust scorer is always right about *now*. The ML model is trying to be right about *what is coming* — predicting the clinical condition earlier than any threshold-based rule can, by learning from `simulator_state` ground truth labels attached to every reading.
+
+---
+
+## Clinical States
+
+Each simulated patient holds one of six clinical states and transitions between them probabilistically on every tick. The `simulator_state` field is included in every emitted message as ground truth for the PySpark ML model — it is never read by the Rust NEWS2 scorer.
+
+### Stable
+
+Normal physiology. All seven NEWS2 parameters are within healthy ranges. This is the baseline state most patients start in and the target of any recovery trajectory. NEWS2 score is typically 0–2.
+
+| Parameter | Range |
+|---|---|
+| Respiratory rate | 12–20 breaths/min |
+| SpO₂ | 95–99% |
+| Supplemental O₂ | No |
+| Temperature | 36.1–37.2 °C |
+| Systolic BP | 110–130 mmHg |
+| Heart rate | 60–80 bpm |
+| Consciousness | Alert |
+
+---
+
+### Deteriorating — Sepsis
+
+Infection-driven organ dysfunction. Sepsis is defined clinically by at least two of: respiratory rate ≥ 22, systolic BP ≤ 100 mmHg, or altered consciousness. Presents with high fever, elevated heart rate, low blood pressure, and elevated respiratory rate as the body mounts a systemic inflammatory response. NEWS2 score typically 4–7.
+
+| Parameter | Range |
+|---|---|
+| Respiratory rate | 20–30 breaths/min |
+| SpO₂ | 93–97% |
+| Supplemental O₂ | ~20% chance |
+| Temperature | 38.5–40.0 °C |
+| Systolic BP | 85–105 mmHg |
+| Heart rate | 100–140 bpm |
+| Consciousness | Alert or Voice |
+
+---
+
+### Deteriorating — Respiratory
+
+Acute respiratory failure. Respiratory rate is often the first and most sensitive sign of clinical decline. Presents with very high breathing effort, low oxygen saturation, and mandatory supplemental oxygen. May co-occur with cardiac or septic presentations. NEWS2 score typically 5–8.
+
+| Parameter | Range |
+|---|---|
+| Respiratory rate | 25–35 breaths/min |
+| SpO₂ | 88–93% |
+| Supplemental O₂ | Always |
+| Temperature | 36.5–37.5 °C |
+| Systolic BP | 105–125 mmHg |
+| Heart rate | 90–120 bpm |
+| Consciousness | Alert or Voice |
+
+---
+
+### Deteriorating — Cardiac
+
+Cardiovascular instability — low cardiac output, arrhythmia, or early cardiogenic shock. Distinguishable from sepsis by the absence of fever: blood pressure and heart rate are abnormal but temperature is near normal. NEWS2 score typically 4–7.
+
+| Parameter | Range |
+|---|---|
+| Respiratory rate | 18–26 breaths/min |
+| SpO₂ | 92–96% |
+| Supplemental O₂ | ~40% chance |
+| Temperature | 36.0–37.0 °C |
+| Systolic BP | 80–100 mmHg |
+| Heart rate | 100–150 bpm |
+| Consciousness | Alert or Voice |
+
+---
+
+### Post-Op Recovering
+
+Post-surgical state. The patient is through the acute phase but the body is still under systemic stress from anaesthesia and tissue trauma. Vitals are mildly abnormal — slightly elevated heart rate, slightly low blood pressure, moderate respiratory rate — but trending toward stable. NEWS2 score typically 1–4.
+
+| Parameter | Range |
+|---|---|
+| Respiratory rate | 14–22 breaths/min |
+| SpO₂ | 93–97% |
+| Supplemental O₂ | ~30% chance |
+| Temperature | 36.8–37.8 °C |
+| Systolic BP | 100–120 mmHg |
+| Heart rate | 75–95 bpm |
+| Consciousness | Alert |
+
+---
+
+### Septic Shock
+
+End-stage sepsis with cardiovascular collapse. The infection is now refractory to fluid resuscitation: blood pressure is critically low, heart rate is very high, and the patient is in altered consciousness. Carries a high mortality risk. NEWS2 score typically ≥ 7 (emergency threshold).
+
+| Parameter | Range |
+|---|---|
+| Respiratory rate | 25–38 breaths/min |
+| SpO₂ | 85–91% |
+| Supplemental O₂ | Always |
+| Temperature | 38.5–41.0 °C |
+| Systolic BP | 60–85 mmHg |
+| Heart rate | 120–160 bpm |
+| Consciousness | Voice, Pain, or Unresponsive |
 
 ---
 
@@ -93,7 +273,7 @@ Aggregate scores trigger escalation tiers:
 
 ### Data Generation — Go
 
-- **Language**: Go 1.22+
+- **Language**: Go 1.26.2
 - **Kafka client**: [`segmentio/kafka-go`](https://github.com/segmentio/kafka-go)
 - **Concurrency model**: One goroutine per simulated patient, sharing a producer pool via channels
 - **Control plane**: Small HTTP API for admit / discharge / scenario triggering
@@ -230,7 +410,7 @@ A few choices worth calling out for anyone reading the code:
 - **Per-patient keying.** All topics are keyed by `patient_id` to preserve ordering within a patient's stream. Cross-patient ordering doesn't matter clinically.
 - **Compacted admin topic.** `patients.admin` is log-compacted so the scorer can rebuild patient demographics on restart without replaying the full event log.
 - **Rust over Go for the scorer.** Both could do this job. Rust was chosen specifically to demonstrate when predictable latency and zero GC pauses earn their complexity — a real-time clinical alerter is a clean justification.
-- **NEWS2 as a baseline, not the goal.** The PySpark ML pipeline is explicitly framed as "can we beat NEWS2?" rather than "can we replace it?" Interpretability matters in clinical contexts.
+- **Snapshot vs trajectory.** The Rust scorer classifies the current clinical state from a single reading using rule-based pattern matching — fast, deterministic, explainable. The PySpark ML model learns from rolling windows of parameter trajectories to predict deterioration *before* thresholds are crossed. The two layers are complementary, not redundant.
 - **Simulator ground truth.** Every emitted reading carries a hidden `simulator_state` field, used as ground truth for evaluating the ML model. This field is never read by the Rust scorer.
 
 ---

--- a/README.md
+++ b/README.md
@@ -134,15 +134,28 @@ Scale 1 applies to all patients in this simulator. Scale 2 (for COPD / hypercapn
 
 ### Consciousness (ACVPU)
 
-New Confusion was added in NEWS2 (vs the original NEWS) as an early sepsis and hypoxia marker.
+ACVPU is the standard clinical scale for assessing a patient's level of consciousness. New Confusion (C) was added in NEWS2 — absent from the original NEWS — because it is often the earliest sign of sepsis or hypoxia: a patient can be confused while still appearing physically well, and that single finding scores 3 points.
 
-| Level | Score |
-|---|---|
-| Alert | 0 |
-| New Confusion | 3 |
-| Voice | 3 |
-| Pain | 3 |
-| Unresponsive | 3 |
+| Level | Meaning | Score |
+|---|---|---|
+| **A** — Alert | Fully awake and oriented; responds normally | 0 |
+| **C** — New Confusion | Awake but disoriented, rambling, or not making sense | 3 |
+| **V** — Voice | Eyes closed; opens them or moves only when spoken to | 3 |
+| **P** — Pain | No response to voice; moves or grimaces only when pinched | 3 |
+| **U** — Unresponsive | No reaction to voice or pain stimulus | 3 |
+
+Any level below Alert scores 3 — a single consciousness finding overrides an otherwise low aggregate and triggers urgent escalation.
+
+#### Consciousness in the simulator's 6 states
+
+| State | Consciousness | Reasoning |
+|---|---|---|
+| Stable | Always Alert | Healthy baseline |
+| Deteriorating — Sepsis | 70% Alert, 30% Voice | Sepsis can cloud cognition early |
+| Deteriorating — Respiratory | 80% Alert, 20% Voice | Hypoxia gradually impairs cognition |
+| Deteriorating — Cardiac | 80% Alert, 20% Voice | Low cardiac output reduces cerebral perfusion |
+| Post-Op Recovering | Always Alert | Anaesthesia has worn off |
+| Septic Shock | Voice / Pain / Unresponsive equally | Cardiovascular collapse severely impairs brain perfusion |
 
 ### Escalation Thresholds
 

--- a/simulator/cmd/internal/patient.go
+++ b/simulator/cmd/internal/patient.go
@@ -2,47 +2,48 @@ package internal
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type Patient struct {
-	ID string
+	ID    string
+	State SimulatorState
 }
 
-func NewPatient(id string) *Patient {
+func NewPatient() *Patient {
 	return &Patient{
-		ID: id,
+		ID:    uuid.New().String(),
+		State: Stable,
 	}
 }
 
 func (p *Patient) Run() {
+	fmt.Fprintf(os.Stderr, "Start running patient %s streaming...\n", p.ID)
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 
 	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "\t")
 	end := time.After(1 * time.Minute)
 	for {
 		select {
 		case <-ticker.C:
-			enc.Encode(p.templateVitals())
+			fmt.Fprintf(os.Stderr, "==> Patient %s parameters...\n", p.ID)
+			if err := enc.Encode(p.sampleVitals()); err != nil {
+				fmt.Fprintf(os.Stderr, "encode error patient %s: %v\n", p.ID, err)
+				return
+			}
 		case <-end:
 			return
 		}
 	}
 }
 
-func (p *Patient) templateVitals() VitalSigns {
-	return VitalSigns{
-		PatientID:          p.ID,
-		Timestamp:          time.Now().UTC(),
-		RespirationRate:    15,
-		OxygenSaturation:   98,
-		SupplementalO2:     false,
-		Temperature:        37.0,
-		SystolicBP:         120,
-		HeartRate:          72,
-		ConsciousnessLevel: Alert,
-		SimulatorState:     Stable,
-	}
+func (p *Patient) sampleVitals() VitalSigns {
+	p.State = NextState(p.State)
+	return sampleVitals(p.ID, p.State)
 }

--- a/simulator/cmd/internal/state.go
+++ b/simulator/cmd/internal/state.go
@@ -1,0 +1,91 @@
+package internal
+
+import "math/rand"
+
+type SimulatorState string
+
+const (
+	Stable                   SimulatorState = "STABLE"
+	DeterioratingSepsis      SimulatorState = "DETERIORATING_SEPSIS"
+	DeterioratingRespiratory SimulatorState = "DETERIORATING_RESPIRATORY"
+	DeterioratingCardiac     SimulatorState = "DETERIORATING_CARDIAC"
+	PostOpRecovering         SimulatorState = "POST_OP_RECOVERING"
+	SepticShock              SimulatorState = "SEPTIC_SHOCK"
+)
+
+type ConsciousnessLevel string
+
+const (
+	Alert        ConsciousnessLevel = "ALERT"
+	NewConfusion ConsciousnessLevel = "NEW_CONFUSION"
+	Voice        ConsciousnessLevel = "VOICE"
+	Pain         ConsciousnessLevel = "PAIN"
+	Unresponsive ConsciousnessLevel = "UNRESPONSIVE"
+)
+
+type weightedTransition struct {
+	state                 SimulatorState
+	cumulativeProbability float64
+}
+
+var transitions = map[SimulatorState][]weightedTransition{
+	Stable: {
+		{Stable, 0.93},
+		{DeterioratingSepsis, 0.95},
+		{DeterioratingRespiratory, 0.97},
+		{DeterioratingCardiac, 0.98},
+		{PostOpRecovering, 0.99},
+		{SepticShock, 1.00},
+	},
+	DeterioratingSepsis: {
+		{Stable, 0.08},
+		{DeterioratingSepsis, 0.88},
+		{DeterioratingRespiratory, 0.91},
+		{DeterioratingCardiac, 0.93},
+		{PostOpRecovering, 0.95},
+		{SepticShock, 1.00},
+	},
+	DeterioratingRespiratory: {
+		{Stable, 0.08},
+		{DeterioratingSepsis, 0.11},
+		{DeterioratingRespiratory, 0.93},
+		{DeterioratingCardiac, 0.97},
+		{PostOpRecovering, 0.99},
+		{SepticShock, 1.00},
+	},
+	DeterioratingCardiac: {
+		{Stable, 0.08},
+		{DeterioratingSepsis, 0.10},
+		{DeterioratingRespiratory, 0.14},
+		{DeterioratingCardiac, 0.96},
+		{PostOpRecovering, 0.98},
+		{SepticShock, 1.00},
+	},
+	PostOpRecovering: {
+		{Stable, 0.20},
+		{DeterioratingSepsis, 0.24},
+		{DeterioratingRespiratory, 0.28},
+		{DeterioratingCardiac, 0.32},
+		{PostOpRecovering, 0.99},
+		{SepticShock, 1.00},
+	},
+	SepticShock: {
+		{Stable, 0.02},
+		{DeterioratingSepsis, 0.17},
+		{DeterioratingRespiratory, 0.22},
+		{DeterioratingCardiac, 0.27},
+		{PostOpRecovering, 0.30},
+		{SepticShock, 1.00},
+	},
+}
+
+func NextState(current SimulatorState) SimulatorState {
+	r := rand.Float64()
+	for _, t := range transitions[current] {
+		if r < t.cumulativeProbability {
+			return t.state
+		}
+	}
+
+	return current
+}

--- a/simulator/cmd/internal/vitals.go
+++ b/simulator/cmd/internal/vitals.go
@@ -1,22 +1,8 @@
 package internal
 
-import "time"
-
-type SimulatorState string
-
-const (
-	Stable        SimulatorState = "STABLE"
-	Deteriorating SimulatorState = "DETERIORATING"
-	Critical      SimulatorState = "CRITICAL"
-)
-
-type ConsciousnessLevel string
-
-const (
-	Alert        ConsciousnessLevel = "ALERT"
-	Voice        ConsciousnessLevel = "VOICE"
-	Pain         ConsciousnessLevel = "PAIN"
-	Unresponsive ConsciousnessLevel = "UNRESPONSIVE"
+import (
+	"math/rand"
+	"time"
 )
 
 type VitalSigns struct {
@@ -32,4 +18,181 @@ type VitalSigns struct {
 	SystolicBP         int                `json:"systolic_bp"`
 	HeartRate          int                `json:"heart_rate"`
 	ConsciousnessLevel ConsciousnessLevel `json:"consciousness_level"`
+}
+
+func sampleVitals(patientID string, state SimulatorState) VitalSigns {
+	return VitalSigns{
+		PatientID:          patientID,
+		Timestamp:          time.Now().UTC(),
+		SimulatorState:     state,
+		RespirationRate:    sampleRR(state),
+		OxygenSaturation:   sampleSpO2(state),
+		SupplementalO2:     sampleSupplementalO2(state),
+		Temperature:        sampleTemp(state),
+		SystolicBP:         sampleBP(state),
+		HeartRate:          sampleHR(state),
+		ConsciousnessLevel: sampleConsciousness(state),
+	}
+}
+
+func sampleRR(state SimulatorState) int {
+	switch state {
+	case Stable:
+		return randInt(12, 20)
+	case DeterioratingSepsis:
+		return randInt(20, 30)
+	case DeterioratingRespiratory:
+		return randInt(25, 35)
+	case DeterioratingCardiac:
+		return randInt(18, 26)
+	case PostOpRecovering:
+		return randInt(14, 22)
+	case SepticShock:
+		return randInt(25, 38)
+	default:
+		return randInt(12, 20)
+	}
+}
+
+func sampleSpO2(state SimulatorState) int {
+	switch state {
+	case Stable:
+		return randInt(95, 99)
+	case DeterioratingSepsis:
+		return randInt(93, 97)
+	case DeterioratingRespiratory:
+		return randInt(88, 93)
+	case DeterioratingCardiac:
+		return randInt(92, 96)
+	case PostOpRecovering:
+		return randInt(93, 97)
+	case SepticShock:
+		return randInt(85, 91)
+	default:
+		return randInt(95, 99)
+	}
+}
+
+func sampleSupplementalO2(state SimulatorState) bool {
+	switch state {
+	case Stable:
+		return false
+	case DeterioratingSepsis:
+		return rand.Float64() < 0.20
+	case DeterioratingRespiratory:
+		return true
+	case DeterioratingCardiac:
+		return rand.Float64() < 0.40
+	case PostOpRecovering:
+		return rand.Float64() < 0.30
+	case SepticShock:
+		return true
+	default:
+		return false
+	}
+}
+
+func sampleTemp(state SimulatorState) float64 {
+	switch state {
+	case Stable:
+		return randFloat(36.1, 37.2)
+	case DeterioratingSepsis:
+		return randFloat(38.5, 40.0)
+	case DeterioratingRespiratory:
+		return randFloat(36.5, 37.5)
+	case DeterioratingCardiac:
+		return randFloat(36.0, 37.0)
+	case PostOpRecovering:
+		return randFloat(36.8, 37.8)
+	case SepticShock:
+		return randFloat(38.5, 41.0)
+	default:
+		return randFloat(36.1, 37.2)
+	}
+}
+
+func sampleBP(state SimulatorState) int {
+	switch state {
+	case Stable:
+		return randInt(110, 130)
+	case DeterioratingSepsis:
+		return randInt(85, 105)
+	case DeterioratingRespiratory:
+		return randInt(105, 125)
+	case DeterioratingCardiac:
+		return randInt(80, 100)
+	case PostOpRecovering:
+		return randInt(100, 120)
+	case SepticShock:
+		return randInt(60, 85)
+	default:
+		return randInt(110, 130)
+	}
+}
+
+func sampleHR(state SimulatorState) int {
+	switch state {
+	case Stable:
+		return randInt(60, 80)
+	case DeterioratingSepsis:
+		return randInt(100, 140)
+	case DeterioratingRespiratory:
+		return randInt(90, 120)
+	case DeterioratingCardiac:
+		return randInt(100, 150)
+	case PostOpRecovering:
+		return randInt(75, 95)
+	case SepticShock:
+		return randInt(120, 160)
+	default:
+		return randInt(60, 80)
+	}
+}
+
+func sampleConsciousness(state SimulatorState) ConsciousnessLevel {
+	r := rand.Float64()
+	switch state {
+	case Stable, PostOpRecovering:
+		return Alert
+	case DeterioratingSepsis:
+		// NewConfusion is the earliest and most important sepsis marker
+		switch {
+		case r < 0.60:
+			return Alert
+		case r < 0.85:
+			return NewConfusion
+		default:
+			return Voice
+		}
+	case DeterioratingRespiratory, DeterioratingCardiac:
+		// Hypoxia and low cerebral perfusion cause confusion before full unresponsiveness
+		switch {
+		case r < 0.70:
+			return Alert
+		case r < 0.90:
+			return NewConfusion
+		default:
+			return Voice
+		}
+	case SepticShock:
+		// Too severe for mere confusion — cardiovascular collapse impairs brain perfusion deeply
+		switch {
+		case r < 0.33:
+			return Voice
+		case r < 0.66:
+			return Pain
+		default:
+			return Unresponsive
+		}
+	default:
+		return Alert
+	}
+}
+
+func randInt(min, max int) int {
+	return rand.Intn(max-min+1) + min
+}
+
+func randFloat(min, max float64) float64 {
+	return rand.Float64()*(max-min) + min
 }

--- a/simulator/cmd/simulator/main.go
+++ b/simulator/cmd/simulator/main.go
@@ -1,15 +1,26 @@
 package main
 
 import (
+	"flag"
+	"sync"
+
 	"github.com/agusrichard/icu-vitals-stream/simulator/cmd/internal"
 )
 
 func main() {
-	patient := internal.NewPatient("richard")
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		patient.Run()
-	}()
-	<-done
+	patients := flag.Int("patients", 1, "Number of patients to simulate")
+	flag.Parse()
+	println("Number of patients to simulate:", *patients)
+
+	var wg sync.WaitGroup
+	for i := 0; i < *patients; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			patient := internal.NewPatient()
+			patient.Run()
+		}()
+	}
+
+	wg.Wait()
 }

--- a/simulator/go.mod
+++ b/simulator/go.mod
@@ -1,3 +1,5 @@
 module github.com/agusrichard/icu-vitals-stream/simulator
 
 go 1.26
+
+require github.com/google/uuid v1.6.0 // indirect

--- a/simulator/go.sum
+++ b/simulator/go.sum
@@ -1,0 +1,2 @@
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=


### PR DESCRIPTION
## Summary

- Introduces six clinical states (`STABLE`, `DETERIORATING_SEPSIS`, `DETERIORATING_RESPIRATORY`, `DETERIORATING_CARDIAC`, `POST_OP_RECOVERING`, `SEPTIC_SHOCK`) with probabilistic Markov chain transitions between them on every tick
- Replaces static template vitals with per-state sampled vital signs (RR, SpO₂, BP, HR, Temperature, Consciousness) drawn from clinically realistic ranges for each state
- Adds a `--patients` flag to `main.go` so multiple patient goroutines can be spawned concurrently via `sync.WaitGroup`, each with a UUID-generated ID
- Expands README with full NEWS2 scoring tables, clinical state definitions, ACVPU consciousness scale, escalation thresholds, and a Snapshot vs Trajectory section explaining the Rust/PySpark split

## Test plan

- [x] Run `go run ./cmd/simulator --patients 5` and verify each patient emits JSON to stdout every second with a changing `simulator_state`
- [x] Confirm log lines go to stderr and JSON goes to stdout (pipe stdout to `jq` to verify)
- [x] Observe vitals visibly shifting across states over time (HR spiking in sepsis, SpO₂ dropping in respiratory failure)
- [x] Verify `go build ./...` passes with no errors

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)