### PR TITLE
feat(infra,simulator): containerize simulator with multi-stage Dockerfile

### DIFF
--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -1,0 +1,10 @@
+services:
+  simulator:
+    build:
+      target: dev
+    volumes:
+      - ../simulator:/src
+    environment:
+      - PATIENTS=3
+      - BROKERS=localhost:9092
+    restart: "no"

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -7,4 +7,5 @@ services:
     environment:
       - PATIENTS=3
       - BROKERS=localhost:9092
+      - NO_KAFKA=true
     restart: "no"

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -7,4 +7,5 @@ services:
     environment:
       - PATIENTS=3
       - BROKERS=kafka:9092
+      - NO_KAFKA=true
     restart: unless-stopped

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -3,3 +3,8 @@ services:
     build:
       context: ../simulator
       dockerfile: Dockerfile
+      target: runtime
+    environment:
+      - PATIENTS=3
+      - BROKERS=kafka:9092
+    restart: unless-stopped

--- a/simulator/.air.toml
+++ b/simulator/.air.toml
@@ -1,0 +1,11 @@
+root = "."
+tmp_dir = "/tmp/air"
+
+[build]
+cmd         = "go build -o /tmp/air/simulator ./cmd/simulator"
+bin         = "/tmp/air/simulator"
+include_ext = ["go"]
+exclude_dir = ["tmp"]
+
+[log]
+time = false

--- a/simulator/Dockerfile
+++ b/simulator/Dockerfile
@@ -1,10 +1,17 @@
-FROM golang:1.26.2-alpine AS build
+FROM golang:1.26-alpine AS builder
 WORKDIR /src
-COPY go.mod ./
+COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN go build -o /simulator ./cmd/simulator
+RUN go build -ldflags="-s -w" -o /simulator ./cmd/simulator
 
-FROM alpine:3.21
-COPY --from=build /simulator /simulator
+FROM golang:1.26-alpine AS dev
+WORKDIR /src
+RUN go install github.com/air-verse/air@latest
+COPY go.mod go.sum ./
+RUN go mod download
+CMD ["air", "-c", ".air.toml"]
+
+FROM alpine:3.21 AS runtime
+COPY --from=builder /simulator /simulator
 CMD ["/simulator"]

--- a/simulator/Dockerfile
+++ b/simulator/Dockerfile
@@ -14,4 +14,4 @@ CMD ["air", "-c", ".air.toml"]
 
 FROM alpine:3.21 AS runtime
 COPY --from=builder /simulator /simulator
-CMD ["/simulator"]
+CMD /simulator -patients=${PATIENTS:-1} -brokers=${BROKERS:-localhost:9092} -no-kafka=${NO_KAFKA:-false}


### PR DESCRIPTION
## Summary
- Adds a multi-stage `Dockerfile` with `builder`, `dev` (hot-reload via Air), and `runtime` targets, replacing the previous single-stage build
- Introduces `docker-compose.dev.yml` for local development with volume mounts and live reload via Air
- Updates `docker-compose.yml` to target the `runtime` stage and passes runtime config (`PATIENTS`, `BROKERS`, `NO_KAFKA`) via environment variables
- Adds `.air.toml` to configure Air's hot-reload build command for the simulator

## Test plan
- [ ] `docker compose -f docker-compose.yml up` starts 3 patients and emits vital signs to stdout
- [ ] `docker compose -f docker-compose.yml -f docker-compose.dev.yml up` starts via Air; editing a `.go` file triggers rebuild and restart

Closes #7