### PR TITLE
feat(infra): add TimescaleDB and pgweb services with schema migrations

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -46,5 +46,33 @@ services:
       SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
     ports:
       - "8081:8081"
+  timescaledb:
+    container_name: timescaledb
+    image: timescale/timescaledb:2.26.3-pg16
+    environment:
+      POSTGRES_USER: icu
+      POSTGRES_PASSWORD: icu
+      POSTGRES_DB: icu
+    ports:
+      - "5432:5432"
+    volumes:
+      - timescaledb-data:/var/lib/postgresql/data
+      - ./migrations:/docker-entrypoint-initdb.d
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U icu" ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+  pgweb:
+    image: sosedoff/pgweb
+    container_name: timescaledb-pgweb
+    depends_on:
+      - timescaledb
+    ports:
+      - "8082:8081"
+    environment:
+      PGWEB_DATABASE_URL: "postgresql://icu:icu@timescaledb:5432/icu?sslmode=disable"
+    restart: always
 volumes:
   kafka-data:
+  timescaledb-data:

--- a/infra/migrations/001_init.sql
+++ b/infra/migrations/001_init.sql
@@ -1,0 +1,32 @@
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+
+CREATE TABLE scored_readings
+(
+    time                TIMESTAMPTZ NOT NULL,
+    patient_id          TEXT        NOT NULL,
+    simulator_state     TEXT        NOT NULL,
+    respiration_rate    INT,
+    oxygen_saturation   INT,
+    supplemental_o2     BOOLEAN,
+    temperature         DOUBLE PRECISION,
+    systolic_bp         INT,
+    heart_rate          INT,
+    consciousness_level TEXT,
+    news2_score         INT         NOT NULL,
+    news2_tier          TEXT        NOT NULL
+);
+
+SELECT create_hypertable('scored_readings', by_range('time'));
+CREATE INDEX ON scored_readings (patient_id, time DESC);
+
+CREATE TABLE alerts
+(
+    time          TIMESTAMPTZ NOT NULL,
+    patient_id    TEXT        NOT NULL,
+    previous_tier TEXT        NOT NULL,
+    new_tier      TEXT        NOT NULL,
+    news2_score   INT         NOT NULL
+);
+
+SELECT create_hypertable('alerts', by_range('time'));
+CREATE INDEX ON alerts (patient_id, time DESC);


### PR DESCRIPTION
Summary                                                                                     
                                                                                              
  - Add TimescaleDB 2.26.3-pg16 service to Docker Compose with healthcheck and named volume
  - Add infra/migrations/001_init.sql — creates scored_readings and alerts as TimescaleDB     
  hypertables, partitioned by time with patient indexes                                       
  - Add pgweb service for browser-based DB inspection at localhost:8082                       
                                                                                              
  Why TimescaleDB 
                                                                                              
  Time-series data from the ICU simulator is append-only and queried by time range + patient. 
  TimescaleDB hypertables automatically partition rows into time chunks, making range scans
  fast without manual partitioning. The by_range('time') API is the modern syntax introduced  
  in 2.13.        

  Test plan

  - docker compose up timescaledb — container reaches healthy state                           
  - docker exec timescaledb psql -U icu -c "\dt" — lists scored_readings and alerts
  - curl localhost:8082 — pgweb UI loads and shows both tables                                
                                                                                              
  Closes #14 