### PR TITLE
feat(infra): register Avro schemas via one-shot init service

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -40,6 +40,11 @@ services:
     depends_on:
       kafka:
         condition: service_healthy
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8081/subjects" ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
     environment:
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: kafka:9092
@@ -73,6 +78,16 @@ services:
     environment:
       PGWEB_DATABASE_URL: "postgresql://icu:icu@timescaledb:5432/icu?sslmode=disable"
     restart: always
+  schema-registry-init:
+    image: alpine:3.21
+    depends_on:
+      schema-registry:
+        condition: service_healthy
+    volumes:
+      - ./schemas:/schemas
+      - ./scripts:/scripts
+    entrypoint: [ "/bin/sh", "/scripts/register_schemas.sh" ]
+    restart: "no"
 volumes:
   kafka-data:
   timescaledb-data:

--- a/infra/schemas/vitals.alerts.avsc
+++ b/infra/schemas/vitals.alerts.avsc
@@ -1,0 +1,12 @@
+{
+  "type": "record",
+  "name": "VitalAlert",
+  "namespace": "com.icu.vitals",
+  "fields": [
+    {"name": "patient_id",    "type": "string"},
+    {"name": "timestamp",     "type": {"type": "long", "logicalType": "timestamp-millis"}},
+    {"name": "previous_tier", "type": "string"},
+    {"name": "new_tier",      "type": "string"},
+    {"name": "news2_score",   "type": "int"}
+  ]
+}

--- a/infra/schemas/vitals.raw.avsc
+++ b/infra/schemas/vitals.raw.avsc
@@ -1,0 +1,17 @@
+{
+  "type": "record",
+  "name": "VitalSigns",
+  "namespace": "com.icu.vitals",
+  "fields": [
+    {"name": "patient_id",           "type": "string"},
+    {"name": "timestamp",            "type": {"type": "long", "logicalType": "timestamp-millis"}},
+    {"name": "simulator_state",      "type": "string"},
+    {"name": "respiration_rate",     "type": "int"},
+    {"name": "oxygen_saturation",    "type": "int"},
+    {"name": "supplemental_o2",      "type": "boolean"},
+    {"name": "temperature",          "type": "double"},
+    {"name": "systolic_bp",          "type": "int"},
+    {"name": "heart_rate",           "type": "int"},
+    {"name": "consciousness_level",  "type": "string"}
+  ]
+}

--- a/infra/schemas/vitals.scored.avsc
+++ b/infra/schemas/vitals.scored.avsc
@@ -1,0 +1,19 @@
+{
+  "type": "record",
+  "name": "ScoredReading",
+  "namespace": "com.icu.vitals",
+  "fields": [
+    {"name": "patient_id",           "type": "string"},
+    {"name": "timestamp",            "type": {"type": "long", "logicalType": "timestamp-millis"}},
+    {"name": "simulator_state",      "type": "string"},
+    {"name": "respiration_rate",     "type": "int"},
+    {"name": "oxygen_saturation",    "type": "int"},
+    {"name": "supplemental_o2",      "type": "boolean"},
+    {"name": "temperature",          "type": "double"},
+    {"name": "systolic_bp",          "type": "int"},
+    {"name": "heart_rate",           "type": "int"},
+    {"name": "consciousness_level",  "type": "string"},
+    {"name": "news2_score",          "type": "int"},
+    {"name": "news2_tier",           "type": "string"}
+  ]
+}

--- a/infra/scripts/register_schemas.sh
+++ b/infra/scripts/register_schemas.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -e
+
+apk add --no-cache curl jq > /dev/null 2>&1
+
+REGISTRY=${SCHEMA_REGISTRY_URL:-http://schema-registry:8081}
+
+register() {
+  topic=$1
+  file=$2
+  echo "Registering $topic..."
+  curl -s -o /dev/null -w "%{http_code}" \
+    -X POST "$REGISTRY/subjects/$topic-value/versions" \
+    -H "Content-Type: application/vnd.schemaregistry.v1+json" \
+    -d "{\"schema\": $(jq -Rs . < "$file")}"
+  echo " done"
+}
+
+register vitals.raw     /schemas/vitals.raw.avsc
+register vitals.scored  /schemas/vitals.scored.avsc
+register vitals.alerts  /schemas/vitals.alerts.avsc


### PR DESCRIPTION
## Summary

- Add three Avro schemas (`vitals.raw`, `vitals.scored`, `vitals.alerts`) defining the message contracts for all Kafka topics in the pipeline
- Add `infra/scripts/register_schemas.sh` that POSTs each schema to the Confluent Schema Registry REST API using `curl` and `jq`
- Introduce `schema-registry-init` one-shot Alpine container that runs the registration script after the Schema Registry is healthy, then exits
- Add a healthcheck to the `schema-registry` service so dependent services wait for it to be truly ready before proceeding

## Test plan

- [x] Run `docker compose up schema-registry-init`
- [x] Verify `curl http://localhost:8081/subjects` returns `["vitals.raw-value","vitals.scored-value","vitals.alerts-value"]`

Closes #18