### PR TITLE
feat: add kafka-init service to create and configure topics

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -88,6 +88,20 @@ services:
       - ./scripts:/scripts
     entrypoint: [ "/bin/sh", "/scripts/register_schemas.sh" ]
     restart: "no"
+  kafka-init:
+    image: confluentinc/cp-kafka:8.2.0
+    depends_on:
+      kafka:
+        condition: service_healthy
+    entrypoint: [ "/bin/sh", "-c" ]
+    command: |
+      "
+      kafka-topics --create --if-not-exists --bootstrap-server kafka:9092 --topic vitals.raw     --partitions 6 --replication-factor 1 --config retention.ms=3600000
+      kafka-topics --create --if-not-exists --bootstrap-server kafka:9092 --topic vitals.scored  --partitions 1 --replication-factor 1 --config retention.ms=3600000
+      kafka-topics --create --if-not-exists --bootstrap-server kafka:9092 --topic vitals.alerts  --partitions 1 --replication-factor 1 --config retention.ms=3600000
+      echo 'Topics created.'
+      "
+    restart: "no"
 volumes:
   kafka-data:
   timescaledb-data:


### PR DESCRIPTION
## Summary
- Adds `kafka-init` one-shot service to `infra/docker-compose.yml` that runs after Kafka is healthy
- Creates `vitals.raw` (6 partitions), `vitals.scored` (1 partition), and `vitals.alerts` (1 partition) with `--if-not-exists` so re-runs are safe
- Sets `retention.ms=3600000` (1 hour) on all topics — scored readings and alerts are persisted to TimescaleDB so long Kafka retention is unnecessary