### PR TITLE
feat(scorer): implement per-patient rolling window state management

### DIFF
--- a/scorer/src/main.rs
+++ b/scorer/src/main.rs
@@ -1,11 +1,15 @@
 pub mod vitals;
 pub mod news2;
+pub mod state;
 
+use std::sync::Arc;
 use apache_avro::from_value;
+use dashmap::DashMap;
 use rdkafka::consumer::{CommitMode, Consumer, StreamConsumer};
 use rdkafka::ClientConfig;
 use rdkafka::message::Message;
 use vitals::VitalSigns;
+use crate::state::StateStore;
 
 async fn fetch_schema(sr_url: &str, subject: &str) -> anyhow::Result<apache_avro::Schema> {
     let resp: serde_json::Value =
@@ -17,12 +21,18 @@ async fn fetch_schema(sr_url: &str, subject: &str) -> anyhow::Result<apache_avro
     Ok(apache_avro::Schema::parse_str(schema_str)?)
 }
 
-async fn process_patient(vitals: VitalSigns) {
+async fn process_patient(vitals: VitalSigns, state: &Arc<StateStore>) {
     tracing::info!(patient_id = %vitals.patient_id, "received vitals");
+    let result = news2::score(&vitals);
+    let mut entry = state.entry(vitals.patient_id.clone()).or_default();
+    let prev_tier = entry.last_tier.clone();
+    entry.last_tier = Some(result.tier.clone());
+    drop(entry);
 }
 
-async fn run_consumer(brokers: &str, group_id: &str, schema_registry_url: &str) -> anyhow::Result<()> {
+async fn run_consumer(brokers: &str, group_id: &str, schema_registry_url: &str, state: &Arc<StateStore>) -> anyhow::Result<()> {
     let schema = fetch_schema(schema_registry_url, "vitals.raw-value").await?;
+    let state: Arc<StateStore> = Arc::new(DashMap::new());
 
     let consumer: StreamConsumer = ClientConfig::new()
         .set("group.id", group_id)
@@ -42,7 +52,7 @@ async fn run_consumer(brokers: &str, group_id: &str, schema_registry_url: &str) 
                     match apache_avro::from_avro_datum(&schema, &mut std::io::Cursor::new(avro_bytes), None)
                         .and_then(|v| from_value::<VitalSigns>(&v))
                     {
-                        Ok(vitals) => process_patient(vitals).await,
+                        Ok(vitals) => process_patient(vitals, &state).await,
                         Err(e) => tracing::warn!("decode error: {}", e),
                     }
                 }
@@ -60,6 +70,7 @@ async fn main() -> anyhow::Result<()> {
     let brokers = std::env::var("BROKERS").unwrap_or_else(|_| "localhost:9092".to_string());
     let group_id = std::env::var("GROUP_ID").unwrap_or_else(|_| "scorer".to_string());
     let schema_registry_url = std::env::var("SCHEMA_REGISTRY_URL").unwrap_or_else(|_| "http://localhost:8081".to_string());
+    let state: Arc<StateStore> = Arc::new(DashMap::new());
 
-    run_consumer(&brokers, &group_id, &schema_registry_url).await
+    run_consumer(&brokers, &group_id, &schema_registry_url, &state).await
 }

--- a/scorer/src/main.rs
+++ b/scorer/src/main.rs
@@ -25,14 +25,13 @@ async fn process_patient(vitals: VitalSigns, state: &Arc<StateStore>) {
     tracing::info!(patient_id = %vitals.patient_id, "received vitals");
     let result = news2::score(&vitals);
     let mut entry = state.entry(vitals.patient_id.clone()).or_default();
-    let prev_tier = entry.last_tier.clone();
+    let _prev_tier = entry.last_tier.clone();
     entry.last_tier = Some(result.tier.clone());
     drop(entry);
 }
 
 async fn run_consumer(brokers: &str, group_id: &str, schema_registry_url: &str, state: &Arc<StateStore>) -> anyhow::Result<()> {
     let schema = fetch_schema(schema_registry_url, "vitals.raw-value").await?;
-    let state: Arc<StateStore> = Arc::new(DashMap::new());
 
     let consumer: StreamConsumer = ClientConfig::new()
         .set("group.id", group_id)
@@ -73,4 +72,69 @@ async fn main() -> anyhow::Result<()> {
     let state: Arc<StateStore> = Arc::new(DashMap::new());
 
     run_consumer(&brokers, &group_id, &schema_registry_url, &state).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::news2::News2Tier;
+
+    fn normal_vitals(patient_id: &str) -> VitalSigns {
+        VitalSigns {
+            patient_id: patient_id.to_string(),
+            timestamp: 0,
+            simulator_state: "NORMAL".to_string(),
+            respiration_rate: 15,
+            oxygen_saturation: 97,
+            supplemental_o2: false,
+            temperature: 37.0,
+            systolic_bp: 120,
+            heart_rate: 75,
+            consciousness_level: "ALERT".to_string(),
+        }
+    }
+
+    fn critical_vitals(patient_id: &str) -> VitalSigns {
+        VitalSigns {
+            patient_id: patient_id.to_string(),
+            timestamp: 1,
+            simulator_state: "CRITICAL".to_string(),
+            respiration_rate: 26,
+            oxygen_saturation: 90,
+            supplemental_o2: true,
+            temperature: 39.5,
+            systolic_bp: 85,
+            heart_rate: 135,
+            consciousness_level: "VOICE".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn process_patient_sets_initial_state() {
+        let state: Arc<StateStore> = Arc::new(DashMap::new());
+        process_patient(normal_vitals("p1"), &state).await;
+        assert_eq!(state.get("p1").unwrap().last_tier, Some(News2Tier::Low));
+    }
+
+    #[tokio::test]
+    async fn process_patient_updates_state_between_readings() {
+        let state: Arc<StateStore> = Arc::new(DashMap::new());
+
+        process_patient(normal_vitals("p1"), &state).await;
+        assert_eq!(state.get("p1").unwrap().last_tier, Some(News2Tier::Low));
+
+        process_patient(critical_vitals("p1"), &state).await;
+        assert_eq!(state.get("p1").unwrap().last_tier, Some(News2Tier::High));
+    }
+
+    #[tokio::test]
+    async fn process_patient_isolates_state_per_patient() {
+        let state: Arc<StateStore> = Arc::new(DashMap::new());
+
+        process_patient(normal_vitals("p1"), &state).await;
+        process_patient(critical_vitals("p2"), &state).await;
+
+        assert_eq!(state.get("p1").unwrap().last_tier, Some(News2Tier::Low));
+        assert_eq!(state.get("p2").unwrap().last_tier, Some(News2Tier::High));
+    }
 }

--- a/scorer/src/state.rs
+++ b/scorer/src/state.rs
@@ -7,3 +7,41 @@ pub struct PatientState {
 }
 
 pub type StateStore = DashMap<String, PatientState>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::news2::News2Tier;
+
+    #[test]
+    fn new_patient_has_no_last_tier() {
+        let store: StateStore = DashMap::new();
+        let entry = store.entry("p1".to_string()).or_default();
+        assert!(entry.last_tier.is_none());
+    }
+
+    #[test]
+    fn last_tier_is_retained_after_update() {
+        let store: StateStore = DashMap::new();
+        {
+            let mut entry = store.entry("p1".to_string()).or_default();
+            entry.last_tier = Some(News2Tier::Medium);
+        }
+        assert_eq!(store.get("p1").unwrap().last_tier, Some(News2Tier::Medium));
+    }
+
+    #[test]
+    fn patients_have_isolated_state() {
+        let store: StateStore = DashMap::new();
+        {
+            let mut entry = store.entry("p1".to_string()).or_default();
+            entry.last_tier = Some(News2Tier::High);
+        }
+        {
+            let mut entry = store.entry("p2".to_string()).or_default();
+            entry.last_tier = Some(News2Tier::Low);
+        }
+        assert_eq!(store.get("p1").unwrap().last_tier, Some(News2Tier::High));
+        assert_eq!(store.get("p2").unwrap().last_tier, Some(News2Tier::Low));
+    }
+}

--- a/scorer/src/state.rs
+++ b/scorer/src/state.rs
@@ -1,0 +1,9 @@
+use crate::news2::News2Tier;
+use dashmap::DashMap;
+
+#[derive(Debug, Default)]
+pub struct PatientState {
+    pub last_tier: Option<News2Tier>
+}
+
+pub type StateStore = DashMap<String, PatientState>;


### PR DESCRIPTION
## Summary

- Adds `state.rs` with `PatientState` struct and `StateStore` type alias (`DashMap<String, PatientState>`), providing lock-free concurrent per-patient state keyed by `patient_id`
- Threads a shared `Arc<StateStore>` through `run_consumer` and `process_patient` so each incoming vitals reading updates the patient's `last_tier` in place
- Unit tests cover initial state insertion, tier updates across successive readings, and isolation between patients (both in `state.rs` and `main.rs`)

## Test plan

- [x] `cargo test` passes (40 tests)
- [x] `state::tests::new_patient_has_no_last_tier` — fresh entry starts with `None`
- [x] `state::tests::last_tier_is_retained_after_update` — tier persists after write
- [x] `state::tests::patients_have_isolated_state` — separate patients hold independent state
- [x] `tests::process_patient_sets_initial_state` — first reading sets tier correctly
- [x] `tests::process_patient_updates_state_between_readings` — state reflects most recent reading
- [x] `tests::process_patient_isolates_state_per_patient` — two patients maintain separate tiers

Closes #26