### PR TITLE
feat(scorer): persist scored readings and alerts to TimescaleDB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+COMPOSE = docker compose -f infra/docker-compose.yml
+
+.PHONY: infra simulator
+
+infra:
+	$(COMPOSE) up kafka schema-registry timescaledb pgweb schema-registry-init kafka-init
+
+simulator:
+	$(COMPOSE) up simulator

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -65,7 +65,7 @@ services:
       POSTGRES_PASSWORD: icu
       POSTGRES_DB: icu
     ports:
-      - "5432:5432"
+      - "5433:5432"
     volumes:
       - timescaledb-data:/var/lib/postgresql/data
       - ./migrations:/docker-entrypoint-initdb.d

--- a/scorer/.sqlx/query-0e51781edec6b2161e1a918d8df60a004aab1ce455f591b1c121e76f6725d798.json
+++ b/scorer/.sqlx/query-0e51781edec6b2161e1a918d8df60a004aab1ce455f591b1c121e76f6725d798.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO alerts (time, patient_id, previous_tier, new_tier, news2_score)\n         VALUES ($1,$2,$3,$4,$5)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Timestamptz",
+        "Text",
+        "Text",
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "0e51781edec6b2161e1a918d8df60a004aab1ce455f591b1c121e76f6725d798"
+}

--- a/scorer/.sqlx/query-1d5c35aedc62a52ad613cad610831eeb9319dc2ae305723e034dd884fd7f84e7.json
+++ b/scorer/.sqlx/query-1d5c35aedc62a52ad613cad610831eeb9319dc2ae305723e034dd884fd7f84e7.json
@@ -1,0 +1,25 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO scored_readings\n          (time, patient_id, simulator_state, respiration_rate, oxygen_saturation,\n           supplemental_o2, temperature, systolic_bp, heart_rate, consciousness_level,\n           news2_score, news2_tier)\n        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Timestamptz",
+        "Text",
+        "Text",
+        "Int4",
+        "Int4",
+        "Bool",
+        "Float8",
+        "Int4",
+        "Int4",
+        "Text",
+        "Int4",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1d5c35aedc62a52ad613cad610831eeb9319dc2ae305723e034dd884fd7f84e7"
+}

--- a/scorer/src/db.rs
+++ b/scorer/src/db.rs
@@ -1,0 +1,68 @@
+use chrono::{DateTime, TimeZone, Utc};
+use sqlx::PgPool;
+use crate::alert::AlertEvent;
+use crate::news2::News2Result;
+use crate::vitals::VitalSigns;
+
+pub async fn insert_scored_reading(pool: &PgPool, v: &VitalSigns, n: &News2Result) -> anyhow::Result<()> {
+    let time: DateTime<Utc> = Utc.timestamp_millis_opt(v.timestamp).single()
+        .ok_or_else(|| anyhow::anyhow!("invalid timestamp: {}", v.timestamp))?;
+    let tier = format!("{:?}", n.tier);
+    sqlx::query!(
+        r#"
+        INSERT INTO scored_readings
+          (time, patient_id, simulator_state, respiration_rate, oxygen_saturation,
+           supplemental_o2, temperature, systolic_bp, heart_rate, consciousness_level,
+           news2_score, news2_tier)
+        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+        "#,
+        time, v.patient_id, v.simulator_state,
+        v.respiration_rate, v.oxygen_saturation, v.supplemental_o2,
+        v.temperature, v.systolic_bp, v.heart_rate, v.consciousness_level,
+        n.score as i32, tier
+    )
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+pub async fn insert_alert(pool: &PgPool, alert: &AlertEvent) -> anyhow::Result<()> {
+    let time: DateTime<Utc> = Utc.timestamp_millis_opt(alert.timestamp).single()
+        .ok_or_else(|| anyhow::anyhow!("invalid timestamp: {}", alert.timestamp))?;
+    sqlx::query!(
+        "INSERT INTO alerts (time, patient_id, previous_tier, new_tier, news2_score)
+         VALUES ($1,$2,$3,$4,$5)",
+        time, alert.patient_id, alert.previous_tier,
+        alert.new_tier, alert.news2_score
+    )
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{TimeZone, Utc};
+
+    #[test]
+    fn zero_timestamp_is_unix_epoch() {
+        let dt = Utc.timestamp_millis_opt(0).single();
+        assert!(dt.is_some());
+        assert_eq!(dt.unwrap().timestamp_millis(), 0);
+    }
+
+    #[test]
+    fn valid_recent_timestamp_converts() {
+        let ts = 1_700_000_000_000i64; // ~Nov 2023
+        let dt = Utc.timestamp_millis_opt(ts).single();
+        assert!(dt.is_some());
+        assert_eq!(dt.unwrap().timestamp_millis(), ts);
+    }
+
+    #[test]
+    fn overflow_timestamp_returns_none() {
+        // i64::MAX milliseconds exceeds chrono's representable range
+        let dt = Utc.timestamp_millis_opt(i64::MAX).single();
+        assert!(dt.is_none());
+    }
+}

--- a/scorer/src/main.rs
+++ b/scorer/src/main.rs
@@ -4,6 +4,7 @@ pub mod state;
 pub mod alert;
 pub mod patient;
 pub mod schema;
+pub mod db;
 
 use std::sync::Arc;
 use apache_avro::from_value;
@@ -12,6 +13,7 @@ use rdkafka::consumer::{CommitMode, Consumer, StreamConsumer};
 use rdkafka::ClientConfig;
 use rdkafka::message::Message;
 use rdkafka::producer::FutureProducer;
+use sqlx::{Pool, Postgres};
 use vitals::VitalSigns;
 use state::StateStore;
 use patient::process_patient;
@@ -21,6 +23,13 @@ pub struct ScorerContext {
     pub alert_producer: FutureProducer,
     pub alert_schema: RegisteredSchema,
     pub state: StateStore,
+    pub pool: Pool<Postgres>
+}
+
+async fn connect() -> anyhow::Result<Pool<Postgres>> {
+    let db_url = std::env::var("DATABASE_URL")?;
+    let pool = sqlx::PgPool::connect(&db_url).await?;
+    Ok(pool)
 }
 
 async fn run_consumer(brokers: &str, group_id: &str, schema_registry_url: &str, ctx: Arc<ScorerContext>) -> anyhow::Result<()> {
@@ -69,6 +78,7 @@ async fn main() -> anyhow::Result<()> {
             .create()?,
         alert_schema: RegisteredSchema::new(&schema_registry_url, "vitals.alerts-value").await?,
         state: DashMap::new(),
+        pool: connect().await?
     });
 
     run_consumer(&brokers, &group_id, &schema_registry_url, ctx).await
@@ -87,6 +97,7 @@ mod tests {
                 .unwrap(),
             alert_schema: RegisteredSchema::dummy(),
             state: DashMap::new(),
+            pool: sqlx::PgPool::connect_lazy("postgresql://icu:icu@localhost:5433/icu").unwrap(),
         })
     }
 
@@ -147,5 +158,25 @@ mod tests {
 
         assert_eq!(ctx.state.get("p1").unwrap().last_tier, Some(News2Tier::Low));
         assert_eq!(ctx.state.get("p2").unwrap().last_tier, Some(News2Tier::High));
+    }
+
+    #[tokio::test]
+    async fn no_alert_on_first_reading() {
+        // prev_tier is None on first call — the alert condition requires Some(prev),
+        // so no alert path is entered. State must be set and no extra entries created.
+        let ctx = make_ctx();
+        process_patient(normal_vitals("p1"), Arc::clone(&ctx)).await;
+        assert_eq!(ctx.state.get("p1").unwrap().last_tier, Some(News2Tier::Low));
+        assert_eq!(ctx.state.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn no_alert_when_tier_unchanged() {
+        // Two consecutive readings with the same tier: prev_tier == current tier,
+        // so the alert condition is false and state stays at Low.
+        let ctx = make_ctx();
+        process_patient(normal_vitals("p1"), Arc::clone(&ctx)).await;
+        process_patient(normal_vitals("p1"), Arc::clone(&ctx)).await;
+        assert_eq!(ctx.state.get("p1").unwrap().last_tier, Some(News2Tier::Low));
     }
 }

--- a/scorer/src/news2.rs
+++ b/scorer/src/news2.rs
@@ -10,7 +10,7 @@ pub fn score_rr(rr: i32) -> u8 {
     }
 }
 
-pub fn score_spo2(spo2: i32, supplemental_o2: bool) -> u8 {
+pub fn score_spo2(spo2: i32) -> u8 {
     // Scale 1 (no COPD): standard thresholds
     match spo2 {
         ..=91  => 3,
@@ -73,7 +73,7 @@ pub struct News2Result {
 pub fn score(v: &VitalSigns) -> News2Result {
     let scores = [
         score_rr(v.respiration_rate),
-        score_spo2(v.oxygen_saturation, v.supplemental_o2),
+        score_spo2(v.oxygen_saturation),
         score_supplemental_o2(v.supplemental_o2),
         score_temp(v.temperature),
         score_bp(v.systolic_bp),
@@ -156,26 +156,26 @@ mod tests {
 
     #[test]
     fn spo2_boundary_critical() {
-        assert_eq!(score_spo2(91, false), 3);
-        assert_eq!(score_spo2(80, false), 3);
+        assert_eq!(score_spo2(91), 3);
+        assert_eq!(score_spo2(80), 3);
     }
 
     #[test]
     fn spo2_boundary_low() {
-        assert_eq!(score_spo2(92, false), 2);
-        assert_eq!(score_spo2(93, false), 2);
+        assert_eq!(score_spo2(92), 2);
+        assert_eq!(score_spo2(93), 2);
     }
 
     #[test]
     fn spo2_boundary_borderline() {
-        assert_eq!(score_spo2(94, false), 1);
-        assert_eq!(score_spo2(95, false), 1);
+        assert_eq!(score_spo2(94), 1);
+        assert_eq!(score_spo2(95), 1);
     }
 
     #[test]
     fn spo2_boundary_normal() {
-        assert_eq!(score_spo2(96, false), 0);
-        assert_eq!(score_spo2(100, false), 0);
+        assert_eq!(score_spo2(96), 0);
+        assert_eq!(score_spo2(100), 0);
     }
 
     // --- score_supplemental_o2 ---

--- a/scorer/src/patient.rs
+++ b/scorer/src/patient.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 use crate::alert::{emit_alert, AlertEvent};
+use crate::db::{insert_alert, insert_scored_reading};
 use crate::news2;
 use crate::vitals::VitalSigns;
 use crate::ScorerContext;
@@ -12,6 +13,9 @@ pub async fn process_patient(vitals: VitalSigns, ctx: Arc<ScorerContext>) {
     entry.last_tier = Some(result.tier.clone());
     drop(entry);
 
+    if let Err(e) = insert_scored_reading(&ctx.pool, &vitals, &result).await {
+        tracing::warn!("insert_scored_reading failed: {}", e);
+    }
     if prev_tier.as_ref() != Some(&result.tier)
         && let Some(prev) = prev_tier
     {
@@ -24,6 +28,9 @@ pub async fn process_patient(vitals: VitalSigns, ctx: Arc<ScorerContext>) {
         };
         if let Err(e) = emit_alert(&ctx.alert_producer, &ctx.alert_schema, &alert).await {
             tracing::warn!("alert emit failed: {}", e);
+        }
+        if let Err(e) = insert_alert(&ctx.pool, &alert).await {
+            tracing::warn!("insert_alert failed: {}", e);
         }
     }
 }

--- a/simulator/cmd/simulator/patient.go
+++ b/simulator/cmd/simulator/patient.go
@@ -27,7 +27,7 @@ func NewPatient(p producer.Producer) *Patient {
 
 func (p *Patient) Run(ctx context.Context) {
 	internal.LogInfo("Start running patient %s streaming...\n", p.ID)
-	ticker := time.NewTicker(1 * time.Second)
+	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 
 	enc := json.NewEncoder(os.Stdout)


### PR DESCRIPTION
## Summary
- Adds `db.rs` with `insert_scored_reading` and `insert_alert` async functions that write to TimescaleDB via sqlx, wired into `process_patient` after each score and alert event
- Adds `connect()` in `main.rs` to establish a `PgPool` from `DATABASE_URL`, injected into `ScorerContext`
- Fixes TimescaleDB port mapping from `5432` to `5433` to avoid conflict with local Homebrew Postgres; inter-container traffic still uses `timescaledb:5432`
- Simplifies `score_spo2` signature by dropping the unused `supplemental_o2` parameter (already handled by a dedicated scorer)
- Commits `.sqlx/` offline query cache so builds work without a live database

## Test plan
- [x] `cargo test` — all 49 tests pass
- [x] `docker compose up` — run full pipeline and verify row counts in TimescaleDB
  ```bash
  psql postgresql://icu:icu@localhost:5433/icu \
    -c "SELECT COUNT(*) FROM scored_readings; SELECT COUNT(*) FROM alerts;"
  ```

Closes #30