### PR TITLE
feat(scorer): containerize Rust scorer service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,4 @@ infra:
 	$(COMPOSE) up kafka schema-registry timescaledb pgweb schema-registry-init kafka-init
 
 simulator:
-	$(COMPOSE) up simulator
+	$(COMPOSE) up simulator scorer

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -94,6 +94,24 @@ services:
       - ./scripts:/scripts
     entrypoint: [ "/bin/sh", "/scripts/register_schemas.sh" ]
     restart: "no"
+  scorer:
+    container_name: rust-scorer
+    build:
+      context: ../scorer
+      dockerfile: Dockerfile
+    depends_on:
+      kafka:
+        condition: service_healthy
+      timescaledb:
+        condition: service_healthy
+      schema-registry-init:
+        condition: service_completed_successfully
+    environment:
+      - BROKERS=kafka:9092
+      - GROUP_ID=scorer
+      - SCHEMA_REGISTRY_URL=http://schema-registry:8081
+      - DATABASE_URL=postgresql://icu:icu@timescaledb:5432/icu
+    restart: unless-stopped
   kafka-init:
     image: confluentinc/cp-kafka:8.2.0
     depends_on:

--- a/scorer/Dockerfile
+++ b/scorer/Dockerfile
@@ -1,0 +1,18 @@
+FROM rust:1.92-alpine AS builder
+WORKDIR /src
+
+RUN apk add --no-cache musl-dev cmake make g++ openssl-dev openssl-libs-static pkgconfig curl-dev zlib-static
+
+COPY Cargo.toml Cargo.lock ./
+RUN mkdir src && echo "fn main(){}" > src/main.rs
+RUN cargo build --release && rm -rf src
+
+COPY src ./src
+COPY .sqlx ./.sqlx
+ENV SQLX_OFFLINE=true
+RUN touch src/main.rs && cargo build --release
+
+FROM alpine:3.21 AS runtime
+RUN apk add --no-cache ca-certificates libgcc
+COPY --from=builder /src/target/release/scorer /scorer
+CMD ["/scorer"]


### PR DESCRIPTION
## Summary

- Add multi-stage `scorer/Dockerfile`: Alpine builder with static musl linking, minimal Alpine runtime image
- Add `scorer` service to `infra/docker-compose.yml` with health-checked dependencies on Kafka, TimescaleDB, and schema-registry-init
- Update `Makefile` `simulator` target to also bring up the scorer

## Notes

The Dockerfile handles several Alpine/musl-specific build requirements:
- `openssl-libs-static` + `zlib-static` for fully static linking (`-lssl`, `-lcrypto`, `-lz`)
- `curl-dev` because librdkafka 2.12.1 includes `curl/curl.h` unconditionally regardless of `-DWITH_CURL=0`
- `.sqlx/` cache copied in with `SQLX_OFFLINE=true` so `sqlx::query!` macros compile without a live database

Closes #33