### PR TITLE
feat(simulator): implement drift-based vital signs with unit tests

### DIFF
--- a/simulator/cmd/simulator/patient.go
+++ b/simulator/cmd/simulator/patient.go
@@ -12,9 +12,11 @@ import (
 )
 
 type Patient struct {
-	ID       string
-	State    internal.SimulatorState
-	producer producer.Producer
+	ID            string
+	State         internal.SimulatorState
+	producer      producer.Producer
+	currentVitals internal.VitalSigns
+	initialized   bool
 }
 
 func NewPatient(p producer.Producer) *Patient {
@@ -41,8 +43,8 @@ func (p *Patient) Run(ctx context.Context) {
 				return
 			}
 			if err := p.producer.Send(vitals); err != nil {
-					internal.LogErr(err, "send error patient %s", p.ID)
-				}
+				internal.LogErr(err, "send error patient %s", p.ID)
+			}
 		case <-ctx.Done():
 			return
 		}
@@ -51,5 +53,11 @@ func (p *Patient) Run(ctx context.Context) {
 
 func (p *Patient) sampleVitals() internal.VitalSigns {
 	p.State = internal.NextState(p.State)
-	return internal.SampleVitals(p.ID, p.State)
+	if !p.initialized {
+		p.currentVitals = internal.InitVitals(p.ID, p.State)
+		p.initialized = true
+	} else {
+		p.currentVitals = internal.DriftVitals(p.ID, p.State, p.currentVitals)
+	}
+	return p.currentVitals
 }

--- a/simulator/cmd/simulator/patient_test.go
+++ b/simulator/cmd/simulator/patient_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/agusrichard/icu-vitals-stream/simulator/internal"
+	"github.com/agusrichard/icu-vitals-stream/simulator/producer"
+)
+
+func newTestPatient() *Patient {
+	return NewPatient(producer.NewNoopProducer())
+}
+
+// TestNewPatientStartsUninitialized verifies that a freshly created patient
+// has not yet sampled any vitals.
+func TestNewPatientStartsUninitialized(t *testing.T) {
+	p := newTestPatient()
+	if p.initialized {
+		t.Error("expected initialized to be false on a new patient")
+	}
+}
+
+// TestPatientFirstSampleInitializes verifies that the first sampleVitals call
+// sets the initialized flag and populates currentVitals with the patient's own ID.
+func TestPatientFirstSampleInitializes(t *testing.T) {
+	p := newTestPatient()
+
+	vitals := p.sampleVitals()
+
+	if !p.initialized {
+		t.Error("expected initialized to be true after first sampleVitals call")
+	}
+	if p.currentVitals.PatientID != p.ID {
+		t.Errorf("currentVitals.PatientID = %q, want %q", p.currentVitals.PatientID, p.ID)
+	}
+	if vitals.PatientID != p.ID {
+		t.Errorf("returned vitals.PatientID = %q, want %q", vitals.PatientID, p.ID)
+	}
+}
+
+// TestPatientReturnedVitalsMatchCurrentVitals verifies that sampleVitals always
+// returns the same value stored in currentVitals across multiple ticks.
+func TestPatientReturnedVitalsMatchCurrentVitals(t *testing.T) {
+	p := newTestPatient()
+
+	for range 10 {
+		returned := p.sampleVitals()
+		if returned != p.currentVitals {
+			t.Errorf("returned vitals do not match currentVitals after tick")
+		}
+	}
+}
+
+// TestPatientDriftUsesCurrentVitalsAsPrev verifies that after initialization,
+// subsequent ticks produce readings that carry the patient's ID and a valid state,
+// confirming DriftVitals is called rather than InitVitals.
+func TestPatientDriftUsesCurrentVitalsAsPrev(t *testing.T) {
+	p := newTestPatient()
+
+	// Prime with a known extreme currentVitals so that drift from it
+	// produces values far from what a fresh InitVitals would sample.
+	p.initialized = true
+	p.State = internal.SepticShock
+	p.currentVitals = internal.VitalSigns{
+		PatientID:          p.ID,
+		SimulatorState:     internal.SepticShock,
+		HeartRate:          20,
+		RespirationRate:    4,
+		OxygenSaturation:   60,
+		Temperature:        32.0,
+		SystolicBP:         40,
+		ConsciousnessLevel: internal.Unresponsive,
+	}
+
+	vitals := p.sampleVitals()
+
+	// After one drift tick from HR=20 toward SepticShock target (140),
+	// HR must have moved upward — it cannot still be at 20 (which is the clamp floor).
+	if vitals.HeartRate <= 20 {
+		t.Errorf("expected HR to drift above 20 from extreme starting value, got %d", vitals.HeartRate)
+	}
+	if vitals.PatientID != p.ID {
+		t.Errorf("vitals.PatientID = %q, want %q", vitals.PatientID, p.ID)
+	}
+}

--- a/simulator/internal/vitals.go
+++ b/simulator/internal/vitals.go
@@ -19,6 +19,76 @@ type VitalSigns struct {
 	ConsciousnessLevel ConsciousnessLevel `json:"consciousness_level"`
 }
 
+type vitalTargets struct {
+	respirationRate  float64
+	oxygenSaturation float64
+	temperature      float64
+	systolicBP       float64
+	heartRate        float64
+}
+
+var stateTargetCenters = map[SimulatorState]vitalTargets{
+	Stable: {
+		respirationRate:  16,
+		oxygenSaturation: 97,
+		temperature:      36.65,
+		systolicBP:       120,
+		heartRate:        70,
+	},
+	DeterioratingSepsis: {
+		respirationRate:  25,
+		oxygenSaturation: 95,
+		temperature:      39.25,
+		systolicBP:       95,
+		heartRate:        120,
+	},
+	DeterioratingRespiratory: {
+		respirationRate:  30,
+		oxygenSaturation: 90.5,
+		temperature:      37.0,
+		systolicBP:       115,
+		heartRate:        105,
+	},
+	DeterioratingCardiac: {
+		respirationRate:  22,
+		oxygenSaturation: 94,
+		temperature:      36.5,
+		systolicBP:       90,
+		heartRate:        125,
+	},
+	PostOpRecovering: {
+		respirationRate:  18,
+		oxygenSaturation: 95,
+		temperature:      37.3,
+		systolicBP:       110,
+		heartRate:        85,
+	},
+	SepticShock: {
+		respirationRate:  31.5,
+		oxygenSaturation: 88,
+		temperature:      39.75,
+		systolicBP:       72.5,
+		heartRate:        140,
+	},
+}
+
+var driftRates = map[SimulatorState]float64{
+	Stable:                   0.10,
+	DeterioratingSepsis:      0.20,
+	DeterioratingRespiratory: 0.20,
+	DeterioratingCardiac:     0.20,
+	PostOpRecovering:         0.15,
+	SepticShock:              0.30,
+}
+
+var noiseAmplitudes = vitalTargets{
+	respirationRate:  1,
+	oxygenSaturation: 1,
+	temperature:      0.1,
+	systolicBP:       3,
+	heartRate:        3,
+}
+
 func SampleVitals(patientID string, state SimulatorState) VitalSigns {
 	return VitalSigns{
 		PatientID:          patientID,

--- a/simulator/internal/vitals.go
+++ b/simulator/internal/vitals.go
@@ -89,7 +89,7 @@ var noiseAmplitudes = vitalTargets{
 	heartRate:        3,
 }
 
-func SampleVitals(patientID string, state SimulatorState) VitalSigns {
+func InitVitals(patientID string, state SimulatorState) VitalSigns {
 	return VitalSigns{
 		PatientID:          patientID,
 		Timestamp:          time.Now().UTC(),
@@ -101,6 +101,53 @@ func SampleVitals(patientID string, state SimulatorState) VitalSigns {
 		SystolicBP:         sampleBP(state),
 		HeartRate:          sampleHR(state),
 		ConsciousnessLevel: sampleConsciousness(state),
+	}
+}
+
+func DriftVitals(patientID string, state SimulatorState, prev VitalSigns) VitalSigns {
+	targets := stateTargetCenters[state]
+	rate := driftRates[state]
+
+	noise := func(amplitude float64) float64 {
+		return rand.Float64()*2*amplitude - amplitude
+	}
+
+	drift := func(prev, target, amplitude float64) float64 {
+		return prev + rate*(target-prev) + noise(amplitude)
+	}
+
+	clamp := func(v, min, max float64) float64 {
+		if v < min {
+			return min
+		}
+		if v > max {
+			return max
+		}
+		return v
+	}
+
+	rr := clamp(drift(float64(prev.RespirationRate), targets.respirationRate, noiseAmplitudes.respirationRate), 4, 60)
+	spo2 := clamp(drift(float64(prev.OxygenSaturation), targets.oxygenSaturation, noiseAmplitudes.oxygenSaturation), 60, 100)
+	temp := clamp(drift(prev.Temperature, targets.temperature, noiseAmplitudes.temperature), 32.0, 43.0)
+	sbp := clamp(drift(float64(prev.SystolicBP), targets.systolicBP, noiseAmplitudes.systolicBP), 40, 260)
+	hr := clamp(drift(float64(prev.HeartRate), targets.heartRate, noiseAmplitudes.heartRate), 20, 220)
+
+	consciousness := prev.ConsciousnessLevel
+	if rand.Float64() < 0.15 {
+		consciousness = sampleConsciousness(state)
+	}
+
+	return VitalSigns{
+		PatientID:          patientID,
+		Timestamp:          time.Now().UTC(),
+		SimulatorState:     state,
+		RespirationRate:    int(rr),
+		OxygenSaturation:   int(spo2),
+		SupplementalO2:     sampleSupplementalO2(state),
+		Temperature:        temp,
+		SystolicBP:         int(sbp),
+		HeartRate:          int(hr),
+		ConsciousnessLevel: consciousness,
 	}
 }
 

--- a/simulator/internal/vitals_test.go
+++ b/simulator/internal/vitals_test.go
@@ -1,0 +1,124 @@
+package internal
+
+import (
+	"testing"
+)
+
+// buildStableVitals returns a VitalSigns snapshot at the centre of the Stable range,
+// used as the starting point for drift tests.
+func buildStableVitals() VitalSigns {
+	return VitalSigns{
+		PatientID:          "test-patient",
+		SimulatorState:     Stable,
+		RespirationRate:    16,
+		OxygenSaturation:   97,
+		SupplementalO2:     false,
+		Temperature:        36.65,
+		SystolicBP:         120,
+		HeartRate:          70,
+		ConsciousnessLevel: Alert,
+	}
+}
+
+// TestDriftConvergence verifies that after 30 ticks drifting toward SepticShock,
+// HR and SBP are measurably closer to the SepticShock target than the Stable starting value.
+func TestDriftConvergence(t *testing.T) {
+	vitals := buildStableVitals()
+
+	for range 30 {
+		vitals = DriftVitals("test-patient", SepticShock, vitals)
+	}
+
+	hrTarget := stateTargetCenters[SepticShock].heartRate
+	hrStart := 70.0
+	hrDistanceAfter := abs(float64(vitals.HeartRate) - hrTarget)
+	hrDistanceBefore := abs(hrStart - hrTarget)
+	if hrDistanceAfter >= hrDistanceBefore {
+		t.Errorf("HR did not converge toward SepticShock target %.1f: started %.1f apart, now %.1f apart",
+			hrTarget, hrDistanceBefore, hrDistanceAfter)
+	}
+
+	sbpTarget := stateTargetCenters[SepticShock].systolicBP
+	sbpStart := 120.0
+	sbpDistanceAfter := abs(float64(vitals.SystolicBP) - sbpTarget)
+	sbpDistanceBefore := abs(sbpStart - sbpTarget)
+	if sbpDistanceAfter >= sbpDistanceBefore {
+		t.Errorf("SBP did not converge toward SepticShock target %.1f: started %.1f apart, now %.1f apart",
+			sbpTarget, sbpDistanceBefore, sbpDistanceAfter)
+	}
+}
+
+// TestDriftClamp verifies that no parameter ever escapes its physiological bounds,
+// even after 100 ticks starting from extreme near-boundary values.
+func TestDriftClamp(t *testing.T) {
+	extreme := VitalSigns{
+		PatientID:          "test-patient",
+		SimulatorState:     SepticShock,
+		RespirationRate:    5,
+		OxygenSaturation:   61,
+		Temperature:        32.1,
+		SystolicBP:         41,
+		HeartRate:          21,
+		ConsciousnessLevel: Unresponsive,
+	}
+
+	for range 100 {
+		extreme = DriftVitals("test-patient", SepticShock, extreme)
+
+		if extreme.HeartRate < 20 || extreme.HeartRate > 220 {
+			t.Errorf("HeartRate %d out of bounds [20, 220]", extreme.HeartRate)
+		}
+		if extreme.RespirationRate < 4 || extreme.RespirationRate > 60 {
+			t.Errorf("RespirationRate %d out of bounds [4, 60]", extreme.RespirationRate)
+		}
+		if extreme.OxygenSaturation < 60 || extreme.OxygenSaturation > 100 {
+			t.Errorf("OxygenSaturation %d out of bounds [60, 100]", extreme.OxygenSaturation)
+		}
+		if extreme.Temperature < 32.0 || extreme.Temperature > 43.0 {
+			t.Errorf("Temperature %.2f out of bounds [32.0, 43.0]", extreme.Temperature)
+		}
+		if extreme.SystolicBP < 40 || extreme.SystolicBP > 260 {
+			t.Errorf("SystolicBP %d out of bounds [40, 260]", extreme.SystolicBP)
+		}
+	}
+}
+
+// TestConsciousnessStableAlwaysAlert verifies that consciousness never changes from Alert
+// when drifting in Stable state, since sampleConsciousness always returns Alert for Stable.
+func TestConsciousnessStableAlwaysAlert(t *testing.T) {
+	vitals := buildStableVitals()
+
+	for range 100 {
+		vitals = DriftVitals("test-patient", Stable, vitals)
+		if vitals.ConsciousnessLevel != Alert {
+			t.Errorf("expected Alert in Stable state, got %s", vitals.ConsciousnessLevel)
+		}
+	}
+}
+
+// TestConsciousnessChangeRate verifies the 15% gate produces a realistic change rate
+// over 200 ticks in DeterioratingSepsis — expected ~30 changes, accepted range [10, 70].
+func TestConsciousnessChangeRate(t *testing.T) {
+	vitals := buildStableVitals()
+	vitals.SimulatorState = DeterioratingSepsis
+
+	changes := 0
+	for range 200 {
+		prev := vitals.ConsciousnessLevel
+		vitals = DriftVitals("test-patient", DeterioratingSepsis, vitals)
+		if vitals.ConsciousnessLevel != prev {
+			changes++
+		}
+	}
+
+	if changes < 10 || changes > 70 {
+		t.Errorf("consciousness changed %d times in 200 ticks; expected between 10 and 70", changes)
+	}
+}
+
+func abs(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}


### PR DESCRIPTION
## Summary

- Replace the single-shot `SampleVitals` with `InitVitals` (first tick) and `DriftVitals` (subsequent ticks), so each patient's readings evolve gradually toward state-specific physiological targets rather than jumping independently each tick
- Add per-state target centres, drift rates, and noise amplitudes so deteriorating/shock states pull vitals more aggressively than stable or recovering states
- Wire the two-phase init/drift logic into `Patient.sampleVitals`, gated by a new `initialized` flag and backed by `currentVitals`
- Add unit tests covering convergence, physiological clamping, consciousness change rate, and the patient tick loop

## Motivation

Without drift, each tick samples vitals independently from state ranges — a Stable→Sepsis transition is an abrupt jump with no trajectory. The PySpark ML model cannot detect deterioration early because there is no pre-threshold signal to learn from. With drift, parameters move gradually toward their new state's target centre, giving the 5-minute rolling window a rising HR slope and falling BP slope before NEWS2 thresholds are crossed.

## Test plan

- [x] `TestDriftConvergence` — HR and SBP converge toward SepticShock target after 30 ticks
- [x] `TestDriftClamp` — no parameter escapes physiological bounds across 100 ticks from extreme values
- [x] `TestConsciousnessStableAlwaysAlert` — consciousness stays Alert in Stable state across 100 ticks
- [x] `TestConsciousnessChangeRate` — consciousness changes 10–70 times across 200 ticks in DeterioratingSepsis
- [x] `TestNewPatientStartsUninitialized` — `initialized` is false on a new patient
- [x] `TestPatientFirstSampleInitializes` — first tick sets `initialized` and stamps `PatientID`
- [x] `TestPatientReturnedVitalsMatchCurrentVitals` — returned value matches `currentVitals` across 10 ticks
- [x] `TestPatientDriftUsesCurrentVitalsAsPrev` — drift from extreme starting values, not a fresh sample

Closes #39