### PR TITLE
feat(infra): add MinIO object storage for Delta Lake

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -40,6 +40,20 @@ services:
       interval: 10s
       timeout: 5s
       retries: 10
+  kafka-init:
+    image: confluentinc/cp-kafka:8.2.0
+    depends_on:
+      kafka:
+        condition: service_healthy
+    entrypoint: [ "/bin/sh", "-c" ]
+    command: |
+      "
+      kafka-topics --create --if-not-exists --bootstrap-server kafka:9092 --topic vitals.raw     --partitions 6 --replication-factor 1 --config retention.ms=3600000
+      kafka-topics --create --if-not-exists --bootstrap-server kafka:9092 --topic vitals.scored  --partitions 1 --replication-factor 1 --config retention.ms=3600000
+      kafka-topics --create --if-not-exists --bootstrap-server kafka:9092 --topic vitals.alerts  --partitions 1 --replication-factor 1 --config retention.ms=3600000
+      echo 'Topics created.'
+      "
+    restart: "no"
   schema-registry:
     container_name: schema-registry
     image: confluentinc/cp-schema-registry:8.2.0
@@ -57,6 +71,16 @@ services:
       SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
     ports:
       - "8081:8081"
+  schema-registry-init:
+    image: alpine:3.21
+    depends_on:
+      schema-registry:
+        condition: service_healthy
+    volumes:
+      - ./schemas:/schemas
+      - ./scripts:/scripts
+    entrypoint: [ "/bin/sh", "/scripts/register_schemas.sh" ]
+    restart: "no"
   timescaledb:
     container_name: timescaledb
     image: timescale/timescaledb:2.26.3-pg16
@@ -84,16 +108,6 @@ services:
     environment:
       PGWEB_DATABASE_URL: "postgresql://icu:icu@timescaledb:5432/icu?sslmode=disable"
     restart: always
-  schema-registry-init:
-    image: alpine:3.21
-    depends_on:
-      schema-registry:
-        condition: service_healthy
-    volumes:
-      - ./schemas:/schemas
-      - ./scripts:/scripts
-    entrypoint: [ "/bin/sh", "/scripts/register_schemas.sh" ]
-    restart: "no"
   scorer:
     container_name: rust-scorer
     build:
@@ -112,20 +126,36 @@ services:
       - SCHEMA_REGISTRY_URL=http://schema-registry:8081
       - DATABASE_URL=postgresql://icu:icu@timescaledb:5432/icu
     restart: unless-stopped
-  kafka-init:
-    image: confluentinc/cp-kafka:8.2.0
+  minio:
+    image: minio/minio:latest
+    container_name: minio
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9000/minio/health/live" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+  minio-init:
+    image: minio/mc:latest
     depends_on:
-      kafka:
+      minio:
         condition: service_healthy
-    entrypoint: [ "/bin/sh", "-c" ]
-    command: |
-      "
-      kafka-topics --create --if-not-exists --bootstrap-server kafka:9092 --topic vitals.raw     --partitions 6 --replication-factor 1 --config retention.ms=3600000
-      kafka-topics --create --if-not-exists --bootstrap-server kafka:9092 --topic vitals.scored  --partitions 1 --replication-factor 1 --config retention.ms=3600000
-      kafka-topics --create --if-not-exists --bootstrap-server kafka:9092 --topic vitals.alerts  --partitions 1 --replication-factor 1 --config retention.ms=3600000
-      echo 'Topics created.'
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 ${MINIO_ROOT_USER:-minioadmin} ${MINIO_ROOT_PASSWORD:-minioadmin};
+      mc mb --ignore-existing local/delta-lake;
+      exit 0
       "
     restart: "no"
 volumes:
   kafka-data:
   timescaledb-data:
+  minio-data:


### PR DESCRIPTION
## Summary

- Add `minio` service with persistent volume and liveness health check to serve as local S3-compatible object storage
- Add `minio-init` service that creates the `delta-lake` bucket on startup, ready for PySpark Delta Lake writes (tasks 22–24)
- Reorganize `docker-compose.yml` so init containers appear adjacent to their parent services

## Test plan

- [x] `docker compose up` starts MinIO without errors
- [x] `delta-lake` bucket is accessible at `http://localhost:9000`
- [x] MinIO console is accessible at `http://localhost:9001`
- [x] Re-running `docker compose up` is idempotent (no error if bucket already exists)

Closes #42