### PR TITLE
feat(pyspark): write aggregated streams to Delta Lake on MinIO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ COMPOSE = docker compose -f infra/docker-compose.yml
 PYSPARK_PACKAGES = org.apache.spark:spark-sql-kafka-0-10_2.13:4.1.1,org.apache.spark:spark-avro_2.13:4.1.1,io.delta:delta-spark_4.1_2.13:4.1.0,org.apache.hadoop:hadoop-aws:3.4.1
 PYSPARK_JOBS_DIR = /opt/spark/jobs
 
-.PHONY: infra simulator all pyspark-submit-raw pyspark-submit-scored pyspark-stop
+.PHONY: infra simulator all pyspark-submit-raw pyspark-submit-scored pyspark-shell pyspark-stop
 
 infra:
 	$(COMPOSE) up --build schema-registry timescaledb pgweb schema-registry-init kafka-init
@@ -31,6 +31,19 @@ pyspark-submit-scored:
 		--packages '$(PYSPARK_PACKAGES)' \
 		--py-files '$(PYSPARK_JOBS_DIR)/shared.py' \
 		$(PYSPARK_JOBS_DIR)/vitals_scored_1hr_agg.py
+
+pyspark-shell:
+	docker exec -it pyspark /opt/spark/bin/pyspark \
+		--master 'local[*]' \
+		--conf 'spark.jars.ivy=/tmp/.ivy2' \
+		--packages '$(PYSPARK_PACKAGES)' \
+		--conf 'spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension' \
+		--conf 'spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog' \
+		--conf 'spark.hadoop.fs.s3a.endpoint=http://minio:9000' \
+		--conf 'spark.hadoop.fs.s3a.access.key=minioadmin' \
+		--conf 'spark.hadoop.fs.s3a.secret.key=minioadmin' \
+		--conf 'spark.hadoop.fs.s3a.path.style.access=true' \
+		--conf 'spark.hadoop.fs.s3a.impl=org.apache.hadoop.fs.s3a.S3AFileSystem'
 
 pyspark-stop:
 	pkill -f 'vitals_raw_5min_agg\|vitals_scored_1hr_agg' || true

--- a/pyspark/jobs/vitals_raw_5min_agg.py
+++ b/pyspark/jobs/vitals_raw_5min_agg.py
@@ -1,17 +1,17 @@
 from pyspark.sql import functions as F
-from pyspark.sql.functions import col, window, avg, min, max, count
+from pyspark.sql.functions import col, window, avg, min, max, count, to_date
 from shared import create_spark_session, fetch_schema, read_kafka_avro_stream
 
 spark = create_spark_session("vitals-raw-5min-agg")
 schema_str = fetch_schema("vitals.raw-value")
 watermarked = (
     read_kafka_avro_stream(spark, "vitals.raw", schema_str)
-    .withWatermark("event_time", "2 minutes")
+    .withWatermark("event_time", "10 minutes")
 )
 
 agg = (
     watermarked
-    .groupBy(col("patient_id"), window(col("event_time"), "1 minutes"))
+    .groupBy(col("patient_id"), window(col("event_time"), "5 minutes"))
     .agg(
         avg("heart_rate").alias("avg_heart_rate"),
         avg("respiration_rate").alias("avg_respiration_rate"),
@@ -37,14 +37,16 @@ agg = (
     )
 )
 
+agg_partitioned = agg.withColumn("window_date", to_date(col("window_start")))
+
 query = (
-    agg.writeStream
+    agg_partitioned.writeStream
     .outputMode("append")
-    .format("console")
-    .option("truncate", False)
+    .format("delta")
     .option("checkpointLocation", "/tmp/checkpoints/vitals_raw_5min_agg")
+    .partitionBy("window_date")
     .trigger(processingTime="30 seconds")
-    .start()
+    .start("s3a://delta-lake/vitals_raw_5min_agg")
 )
 
 query.awaitTermination()

--- a/pyspark/jobs/vitals_scored_1hr_agg.py
+++ b/pyspark/jobs/vitals_scored_1hr_agg.py
@@ -1,17 +1,17 @@
 from pyspark.sql import functions as F
-from pyspark.sql.functions import col, window, avg, min, max, count
+from pyspark.sql.functions import col, window, avg, min, max, count, to_date
 from shared import create_spark_session, fetch_schema, read_kafka_avro_stream
 
 spark = create_spark_session("vitals-scored-1hr-agg")
 schema_str = fetch_schema("vitals.scored-value")
 watermarked = (
     read_kafka_avro_stream(spark, "vitals.scored", schema_str)
-    .withWatermark("event_time", "1 minutes")
+    .withWatermark("event_time", "10 minutes")
 )
 
 agg = (
     watermarked
-    .groupBy(col("patient_id"), window(col("event_time"), "2 minutes"))
+    .groupBy(col("patient_id"), window(col("event_time"), "1 hour"))
     .agg(
         avg("heart_rate").alias("avg_heart_rate"),
         avg("respiration_rate").alias("avg_respiration_rate"),
@@ -43,14 +43,16 @@ agg = (
     )
 )
 
+agg_partitioned = agg.withColumn("window_date", to_date(col("window_start")))
+
 query = (
-    agg.writeStream
+    agg_partitioned.writeStream
     .outputMode("append")
-    .format("console")
-    .option("truncate", False)
+    .format("delta")
     .option("checkpointLocation", "/tmp/checkpoints/vitals_scored_1hr_agg")
-    .trigger(processingTime="30 seconds")
-    .start()
+    .partitionBy("window_date")
+    .trigger(processingTime="5 minutes")
+    .start("s3a://delta-lake/vitals_scored_1hr_agg")
 )
 
 query.awaitTermination()


### PR DESCRIPTION
## Summary

- Replace `format("console")` with `format("delta")` sink in both PySpark streaming jobs, writing to `s3a://delta-lake/` on MinIO
- Restore production window/watermark values: 5-minute window + 10-minute watermark for raw aggregates, 1-hour window + 10-minute watermark + 5-minute trigger for scored aggregates
- Partition output by `window_date` (date extracted from `window_start`) for efficient time-range queries in Grafana and ML jobs

## Test plan

- [x] `make pyspark-submit-raw` writes Parquet files to `s3a://delta-lake/vitals_raw_5min_agg/` with `_delta_log/` present in MinIO
- [x] `make pyspark-submit-scored` writes Parquet files to `s3a://delta-lake/vitals_scored_1hr_agg/` after first sealed 1-hour window (~70 min)
- [x] `make pyspark-shell` then `spark.read.format("delta").load("s3a://delta-lake/vitals_raw_5min_agg")` returns rows with correct schema
- [x] Date-partitioned directories (`window_date=YYYY-MM-DD/`) appear under each table path
- [x] Jobs resume from checkpoint after container restart without writing duplicate rows

Closes #50