### PR TITLE
feat(infra): add Grafana service to Docker Compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ PLANS.md
 simulator/simulator
 target
 .mcp.json
+__pycache__

--- a/grafana/provisioning/dashboards/dashboards.yaml
+++ b/grafana/provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+providers:
+  - name: default
+    type: file
+    updateIntervalSeconds: 30
+    options:
+      path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: false

--- a/grafana/provisioning/datasources/datasources.yaml
+++ b/grafana/provisioning/datasources/datasources.yaml
@@ -1,0 +1,22 @@
+apiVersion: 1
+
+datasources:
+  - name: TimescaleDB
+    type: postgres
+    uid: timescaledb
+    url: timescaledb:5432
+    user: icu
+    secureJsonData:
+      password: icu
+    jsonData:
+      database: icu
+      sslmode: disable
+      timescaledb: true
+      postgresVersion: 1600
+    isDefault: true
+    editable: false
+
+  - name: Infinity
+    type: yesoreyeram-infinity-datasource
+    uid: infinity
+    editable: false

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -171,7 +171,25 @@ services:
       - "4040:4040"   # Spark UI
       - "8080:8080"   # Spark master web UI
     restart: unless-stopped
+  grafana:
+    image: grafana/grafana:13.0.1
+    container_name: grafana
+    depends_on:
+      timescaledb:
+        condition: service_healthy
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_PLUGINS_PREINSTALL_SYNC: yesoreyeram-infinity-datasource
+      GF_USERS_DEFAULT_THEME: dark
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ../grafana/provisioning:/etc/grafana/provisioning
+    ports:
+      - "3000:3000"
+    restart: unless-stopped
 volumes:
   kafka-data:
   timescaledb-data:
   minio-data:
+  grafana-data:


### PR DESCRIPTION
## Summary

- Add Grafana 13.0.1 to Docker Compose with a named `grafana-data` volume for persistence
- Provision TimescaleDB (PostgreSQL 16) as the default datasource via `grafana/provisioning/datasources/datasources.yaml`
- Pre-install the Infinity plugin (`yesoreyeram-infinity-datasource`) synchronously via `GF_PLUGINS_PREINSTALL_SYNC` for the Delta Lake datasource placeholder (wired in Task 27)
- Add dashboard provider config at `grafana/provisioning/dashboards/dashboards.yaml` for Tasks 26/27 to drop dashboard JSON files into

## Test plan

- [x] `docker compose -f infra/docker-compose.yml up grafana -d` starts without errors
- [x] `http://localhost:3000` loads Grafana login page
- [x] **Connections → Data sources → TimescaleDB → Save & test** returns green
- [x] **Administration → Plugins → Infinity** shows as Installed
- [x] No `GF_INSTALL_PLUGINS is deprecated` warning in container logs

Closes #52