### PR TITLE
fix(scorer): publish scored readings to vitals.scored Kafka topic

### DIFF
--- a/scorer/src/main.rs
+++ b/scorer/src/main.rs
@@ -2,6 +2,7 @@ pub mod vitals;
 pub mod news2;
 pub mod state;
 pub mod alert;
+pub mod scored;
 pub mod patient;
 pub mod schema;
 pub mod db;
@@ -22,6 +23,8 @@ use schema::RegisteredSchema;
 pub struct ScorerContext {
     pub alert_producer: FutureProducer,
     pub alert_schema: RegisteredSchema,
+    pub scored_producer: FutureProducer,
+    pub scored_schema: RegisteredSchema,
     pub state: StateStore,
     pub pool: Pool<Postgres>
 }
@@ -77,6 +80,10 @@ async fn main() -> anyhow::Result<()> {
             .set("bootstrap.servers", &brokers)
             .create()?,
         alert_schema: RegisteredSchema::new(&schema_registry_url, "vitals.alerts-value").await?,
+        scored_producer: ClientConfig::new()
+            .set("bootstrap.servers", &brokers)
+            .create()?,
+        scored_schema: RegisteredSchema::new(&schema_registry_url, "vitals.scored-value").await?,
         state: DashMap::new(),
         pool: connect().await?
     });
@@ -96,6 +103,11 @@ mod tests {
                 .create()
                 .unwrap(),
             alert_schema: RegisteredSchema::dummy(),
+            scored_producer: ClientConfig::new()
+                .set("bootstrap.servers", "localhost:9092")
+                .create()
+                .unwrap(),
+            scored_schema: RegisteredSchema::dummy(),
             state: DashMap::new(),
             pool: sqlx::PgPool::connect_lazy("postgresql://icu:icu@localhost:5433/icu").unwrap(),
         })

--- a/scorer/src/patient.rs
+++ b/scorer/src/patient.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 use crate::alert::{emit_alert, AlertEvent};
+use crate::scored::{emit_scored, ScoredReading};
 use crate::db::{insert_alert, insert_scored_reading};
 use crate::news2;
 use crate::vitals::VitalSigns;
@@ -15,6 +16,23 @@ pub async fn process_patient(vitals: VitalSigns, ctx: Arc<ScorerContext>) {
 
     if let Err(e) = insert_scored_reading(&ctx.pool, &vitals, &result).await {
         tracing::warn!("insert_scored_reading failed: {}", e);
+    }
+    let reading = ScoredReading {
+        patient_id: vitals.patient_id.clone(),
+        timestamp: vitals.timestamp,
+        simulator_state: vitals.simulator_state.clone(),
+        respiration_rate: vitals.respiration_rate,
+        oxygen_saturation: vitals.oxygen_saturation,
+        supplemental_o2: vitals.supplemental_o2,
+        temperature: vitals.temperature,
+        systolic_bp: vitals.systolic_bp,
+        heart_rate: vitals.heart_rate,
+        consciousness_level: vitals.consciousness_level.clone(),
+        news2_score: result.score as i32,
+        news2_tier: format!("{:?}", result.tier),
+    };
+    if let Err(e) = emit_scored(&ctx.scored_producer, &ctx.scored_schema, &reading).await {
+        tracing::warn!("scored emit failed: {}", e);
     }
     if prev_tier.as_ref() != Some(&result.tier)
         && let Some(prev) = prev_tier

--- a/scorer/src/scored.rs
+++ b/scorer/src/scored.rs
@@ -1,0 +1,39 @@
+use rdkafka::producer::{FutureProducer, FutureRecord};
+use crate::schema::RegisteredSchema;
+
+#[derive(serde::Serialize)]
+pub struct ScoredReading {
+    pub patient_id: String,
+    pub timestamp: i64,
+    pub simulator_state: String,
+    pub respiration_rate: i32,
+    pub oxygen_saturation: i32,
+    pub supplemental_o2: bool,
+    pub temperature: f64,
+    pub systolic_bp: i32,
+    pub heart_rate: i32,
+    pub consciousness_level: String,
+    pub news2_score: i32,
+    pub news2_tier: String,
+}
+
+pub async fn emit_scored(
+    producer: &FutureProducer,
+    registered: &RegisteredSchema,
+    reading: &ScoredReading,
+) -> anyhow::Result<()> {
+    let value = apache_avro::to_value(reading)?;
+    let avro_bytes = apache_avro::to_avro_datum(&registered.schema, value)?;
+
+    let mut msg = Vec::with_capacity(5 + avro_bytes.len());
+    msg.push(0x00);
+    msg.extend_from_slice(&registered.id.to_be_bytes());
+    msg.extend_from_slice(&avro_bytes);
+
+    let record = FutureRecord::to("vitals.scored")
+        .key(&reading.patient_id)
+        .payload(&msg);
+    producer.send(record, rdkafka::util::Timeout::Never).await
+        .map_err(|(e, _)| anyhow::anyhow!(e))?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- The Rust scorer was writing scores to TimescaleDB but never producing to the `vitals.scored` Kafka topic, leaving it empty and starving the PySpark 1-hour aggregation job of input
- Add `scored.rs` with a `ScoredReading` struct and `emit_scored` function (mirrors `alert.rs` pattern, targets `vitals.scored`)
- Add `scored_producer` and `scored_schema` to `ScorerContext` in `main.rs`
- Call `emit_scored` in `process_patient` after each `insert_scored_reading`

## Test plan

- [x] `vitals.scored` topic receives messages after scorer restart
- [x] PySpark `vitals_scored_1hr_agg` job writes its first Delta Lake commit within ~70 minutes
- [x] `docker exec minio mc ls --recursive local/delta-lake/vitals_scored_1hr_agg/` shows `_delta_log/` and Parquet files