### PR TITLE
feat(grafana): add ward KPIs dashboard sourced from Delta Lake

### DIFF
--- a/delta-reader/Dockerfile
+++ b/delta-reader/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app.py .
+EXPOSE 5000
+CMD ["python", "app.py"]

--- a/delta-reader/app.py
+++ b/delta-reader/app.py
@@ -1,0 +1,74 @@
+import os
+from datetime import datetime, timezone, timedelta
+import pandas as pd
+from deltalake import DeltaTable
+from flask import Flask, jsonify
+
+app = Flask(__name__)
+
+STORAGE_OPTIONS = {
+    "AWS_ENDPOINT_URL": os.getenv("MINIO_ENDPOINT", "http://minio:9000"),
+    "AWS_ACCESS_KEY_ID": os.getenv("MINIO_ACCESS_KEY", "minioadmin"),
+    "AWS_SECRET_ACCESS_KEY": os.getenv("MINIO_SECRET_KEY", "minioadmin"),
+    "AWS_REGION": "us-east-1",
+    "AWS_ALLOW_HTTP": "true",
+}
+SCORED_1HR_TABLE = os.getenv("SCORED_1HR_TABLE", "s3://delta-lake/vitals_scored_1hr_agg")
+
+
+def read_scored_1hr() -> pd.DataFrame:
+    dt = DeltaTable(SCORED_1HR_TABLE, storage_options=STORAGE_OPTIONS)
+    return dt.to_pandas()
+
+
+def latest_window_per_patient(df: pd.DataFrame) -> pd.DataFrame:
+    idx = df.groupby("patient_id")["window_start"].idxmax()
+    return df.loc[idx]
+
+
+@app.route("/api/ward/summary")
+def ward_summary():
+    df = read_scored_1hr()
+    latest = latest_window_per_patient(df)
+    total = len(latest)
+    high = int((latest["news2_tier"] == "High").sum())
+    medium = int((latest["news2_tier"] == "Medium").sum())
+    low = int((latest["news2_tier"] == "Low").sum())
+    avg_news2 = round(float(latest["avg_news2_score"].mean()), 2) if total > 0 else 0.0
+    return jsonify([{
+        "total_patients": total,
+        "high_count": high,
+        "medium_count": medium,
+        "low_count": low,
+        "avg_news2_score": avg_news2,
+    }])
+
+
+@app.route("/api/ward/news2-trend")
+def news2_trend():
+    df = read_scored_1hr()
+    cutoff = datetime.now(tz=timezone.utc) - timedelta(hours=24)
+    df["window_start"] = pd.to_datetime(df["window_start"], utc=True)
+    recent = df[df["window_start"] >= cutoff]
+    trend = (
+        recent.groupby("window_start")["avg_news2_score"]
+        .mean()
+        .reset_index()
+        .sort_values("window_start")
+    )
+    trend["window_start"] = trend["window_start"].dt.strftime("%Y-%m-%dT%H:%M:%S+00:00")
+    trend["avg_news2_score"] = trend["avg_news2_score"].round(2)
+    return jsonify(trend.to_dict(orient="records"))
+
+
+@app.route("/api/ward/patient-ranks")
+def patient_ranks():
+    df = read_scored_1hr()
+    latest = latest_window_per_patient(df)
+    ranked = latest[["patient_id", "max_news2_score", "news2_tier", "simulator_state"]].copy()
+    ranked = ranked.sort_values("max_news2_score", ascending=False)
+    return jsonify(ranked.to_dict(orient="records"))
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000, debug=False)

--- a/delta-reader/requirements.txt
+++ b/delta-reader/requirements.txt
@@ -1,0 +1,4 @@
+deltalake==1.5.1
+pyarrow>=14.0.0
+pandas==2.2.3
+Flask==3.1.1

--- a/grafana/provisioning/dashboards/patient_vitals.json
+++ b/grafana/provisioning/dashboards/patient_vitals.json
@@ -11,7 +11,15 @@
   "timepicker": {},
   "timezone": "browser",
   "tags": ["icu", "vitals"],
-  "links": [],
+  "links": [
+    {
+      "title": "Ward KPIs",
+      "url": "/d/ward-kpis",
+      "type": "link",
+      "icon": "external link",
+      "targetBlank": false
+    }
+  ],
   "annotations": { "list": [] },
 
   "templating": {

--- a/grafana/provisioning/dashboards/ward_kpis.json
+++ b/grafana/provisioning/dashboards/ward_kpis.json
@@ -1,0 +1,334 @@
+{
+  "title": "Ward KPIs",
+  "uid": "ward-kpis",
+  "description": "Aggregate clinical metrics across all monitored patients — sourced from Delta Lake via the delta-reader service.",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "graphTooltip": 1,
+  "refresh": "5m",
+  "time": { "from": "now-24h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "tags": ["icu", "ward", "kpis"],
+  "links": [
+    {
+      "title": "Live Patient Vitals",
+      "url": "/d/patient-vitals",
+      "type": "link",
+      "icon": "external link",
+      "targetBlank": false
+    }
+  ],
+  "annotations": { "list": [] },
+  "templating": { "list": [] },
+
+  "panels": [
+
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Total Patients",
+      "gridPos": { "x": 0, "y": 0, "w": 6, "h": 4 },
+      "datasource": { "type": "yesoreyeram-infinity-datasource", "uid": "infinity" },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "auto",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "fixed", "fixedColor": "blue" },
+          "thresholds": { "mode": "absolute", "steps": [] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "yesoreyeram-infinity-datasource", "uid": "infinity" },
+          "type": "json",
+          "source": "url",
+          "url": "http://delta-reader:5000/api/ward/summary",
+          "url_options": { "method": "GET" },
+          "format": "table",
+          "root_selector": "",
+          "columns": [
+            { "selector": "total_patients", "text": "Total Patients", "type": "number" }
+          ]
+        }
+      ]
+    },
+
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "HIGH Risk Patients",
+      "gridPos": { "x": 6, "y": 0, "w": 6, "h": 4 },
+      "datasource": { "type": "yesoreyeram-infinity-datasource", "uid": "infinity" },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "auto",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "fixed", "fixedColor": "red" },
+          "thresholds": { "mode": "absolute", "steps": [] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "yesoreyeram-infinity-datasource", "uid": "infinity" },
+          "type": "json",
+          "source": "url",
+          "url": "http://delta-reader:5000/api/ward/summary",
+          "url_options": { "method": "GET" },
+          "format": "table",
+          "root_selector": "",
+          "columns": [
+            { "selector": "high_count", "text": "HIGH Risk", "type": "number" }
+          ]
+        }
+      ]
+    },
+
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "MEDIUM Risk Patients",
+      "gridPos": { "x": 12, "y": 0, "w": 6, "h": 4 },
+      "datasource": { "type": "yesoreyeram-infinity-datasource", "uid": "infinity" },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "auto",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "fixed", "fixedColor": "orange" },
+          "thresholds": { "mode": "absolute", "steps": [] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "yesoreyeram-infinity-datasource", "uid": "infinity" },
+          "type": "json",
+          "source": "url",
+          "url": "http://delta-reader:5000/api/ward/summary",
+          "url_options": { "method": "GET" },
+          "format": "table",
+          "root_selector": "",
+          "columns": [
+            { "selector": "medium_count", "text": "MEDIUM Risk", "type": "number" }
+          ]
+        }
+      ]
+    },
+
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Ward Average NEWS2 Score",
+      "gridPos": { "x": 18, "y": 0, "w": 6, "h": 4 },
+      "datasource": { "type": "yesoreyeram-infinity-datasource", "uid": "infinity" },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "auto",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green",  "value": null },
+              { "color": "yellow", "value": 3 },
+              { "color": "orange", "value": 5 },
+              { "color": "red",    "value": 7 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "yesoreyeram-infinity-datasource", "uid": "infinity" },
+          "type": "json",
+          "source": "url",
+          "url": "http://delta-reader:5000/api/ward/summary",
+          "url_options": { "method": "GET" },
+          "format": "table",
+          "root_selector": "",
+          "columns": [
+            { "selector": "avg_news2_score", "text": "Avg NEWS2", "type": "number" }
+          ]
+        }
+      ]
+    },
+
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Ward Average NEWS2 Score Trend (last 24h)",
+      "gridPos": { "x": 0, "y": 4, "w": 24, "h": 8 },
+      "datasource": { "type": "yesoreyeram-infinity-datasource", "uid": "infinity" },
+      "options": {
+        "tooltip": { "mode": "single", "sort": "none" },
+        "legend": { "showLegend": false }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green",  "value": null },
+              { "color": "yellow", "value": 3 },
+              { "color": "orange", "value": 5 },
+              { "color": "red",    "value": 7 }
+            ]
+          },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "drawStyle": "line",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "yesoreyeram-infinity-datasource", "uid": "infinity" },
+          "type": "json",
+          "source": "url",
+          "url": "http://delta-reader:5000/api/ward/news2-trend",
+          "url_options": { "method": "GET" },
+          "format": "timeseries",
+          "root_selector": "",
+          "columns": [
+            { "selector": "window_start",    "text": "Time",      "type": "timestamp" },
+            { "selector": "avg_news2_score", "text": "Avg NEWS2", "type": "number" }
+          ]
+        }
+      ]
+    },
+
+    {
+      "id": 6,
+      "type": "bargauge",
+      "title": "Per-Patient Peak NEWS2 Score (latest hour)",
+      "gridPos": { "x": 0, "y": 12, "w": 14, "h": 10 },
+      "datasource": { "type": "yesoreyeram-infinity-datasource", "uid": "infinity" },
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": true }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green",  "value": null },
+              { "color": "yellow", "value": 3 },
+              { "color": "orange", "value": 5 },
+              { "color": "red",    "value": 7 }
+            ]
+          },
+          "min": 0,
+          "max": 20
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "yesoreyeram-infinity-datasource", "uid": "infinity" },
+          "type": "json",
+          "source": "url",
+          "url": "http://delta-reader:5000/api/ward/patient-ranks",
+          "url_options": { "method": "GET" },
+          "format": "table",
+          "root_selector": "",
+          "columns": [
+            { "selector": "patient_id",      "text": "Patient",   "type": "string" },
+            { "selector": "max_news2_score",  "text": "Peak NEWS2", "type": "number" },
+            { "selector": "news2_tier",       "text": "Tier",      "type": "string" }
+          ]
+        }
+      ]
+    },
+
+    {
+      "id": 7,
+      "type": "table",
+      "title": "Patient Risk Ranking (latest hour window)",
+      "gridPos": { "x": 14, "y": 12, "w": 10, "h": 10 },
+      "datasource": { "type": "yesoreyeram-infinity-datasource", "uid": "infinity" },
+      "options": {
+        "sortBy": [{ "desc": true, "displayName": "Peak NEWS2" }],
+        "footer": { "show": false }
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Tier" },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "Low":    { "index": 0, "text": "LOW",    "color": "yellow" },
+                      "Medium": { "index": 1, "text": "MEDIUM", "color": "orange" },
+                      "High":   { "index": 2, "text": "HIGH",   "color": "red"    }
+                    }
+                  }
+                ]
+              },
+              { "id": "custom.displayMode", "value": "color-background" }
+            ]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "yesoreyeram-infinity-datasource", "uid": "infinity" },
+          "type": "json",
+          "source": "url",
+          "url": "http://delta-reader:5000/api/ward/patient-ranks",
+          "url_options": { "method": "GET" },
+          "format": "table",
+          "root_selector": "",
+          "columns": [
+            { "selector": "patient_id",      "text": "Patient",   "type": "string" },
+            { "selector": "max_news2_score",  "text": "Peak NEWS2", "type": "number" },
+            { "selector": "news2_tier",       "text": "Tier",      "type": "string" },
+            { "selector": "simulator_state",  "text": "State",     "type": "string" }
+          ]
+        }
+      ]
+    }
+
+  ]
+}

--- a/grafana/provisioning/datasources/datasources.yaml
+++ b/grafana/provisioning/datasources/datasources.yaml
@@ -20,3 +20,6 @@ datasources:
     type: yesoreyeram-infinity-datasource
     uid: infinity
     editable: false
+    jsonData:
+      allowed_hosts:
+        - http://delta-reader:5000

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -171,6 +171,22 @@ services:
       - "4040:4040"   # Spark UI
       - "8080:8080"   # Spark master web UI
     restart: unless-stopped
+  delta-reader:
+    container_name: delta-reader
+    build:
+      context: ../delta-reader
+      dockerfile: Dockerfile
+    depends_on:
+      minio:
+        condition: service_healthy
+    environment:
+      - MINIO_ENDPOINT=http://minio:9000
+      - MINIO_ACCESS_KEY=${MINIO_ROOT_USER:-minioadmin}
+      - MINIO_SECRET_KEY=${MINIO_ROOT_PASSWORD:-minioadmin}
+      - SCORED_1HR_TABLE=s3://delta-lake/vitals_scored_1hr_agg
+    ports:
+      - "5001:5000"
+    restart: unless-stopped
   grafana:
     image: grafana/grafana:13.0.1
     container_name: grafana


### PR DESCRIPTION
## Summary

- Introduces `delta-reader`, a Flask service using `delta-rs` Python bindings that reads `vitals_scored_1hr_agg` from Delta Lake on MinIO and exposes three JSON endpoints for Grafana
- Adds a `ward_kpis` Grafana dashboard (7 panels) backed by the Infinity datasource: ward-level stat panels, a 24h NEWS2 trend, a per-patient peak NEWS2 bar gauge, and a patient risk ranking table
- Wires the Infinity datasource `allowed_hosts` so Grafana can proxy requests to the `delta-reader` service

## Changes

- `delta-reader/` — Flask API with `/api/ward/summary`, `/api/ward/news2-trend`, `/api/ward/patient-ranks`
- `infra/docker-compose.yml` — `delta-reader` service added (port 5001), depends on MinIO health
- `grafana/provisioning/datasources/datasources.yaml` — `allowed_hosts` added to Infinity entry
- `grafana/provisioning/dashboards/ward_kpis.json` — new 7-panel ward KPIs dashboard
- `grafana/provisioning/dashboards/patient_vitals.json` — cross-link to Ward KPIs added

## Test plan

- [x] `docker compose build delta-reader && docker compose up -d delta-reader` starts cleanly
- [x] `curl http://localhost:5001/api/ward/summary` returns a JSON array with patient counts
- [x] `curl http://localhost:5001/api/ward/patient-ranks` returns one object per simulated patient
- [x] Ward KPIs dashboard appears in Grafana within 30 seconds of restart
- [x] All 7 panels render without "No data" or "URL not allowed" errors
- [x] Per-patient bar gauge shows one bar per patient sorted by peak NEWS2 descending

Closes #57